### PR TITLE
Fix crash when there is no entry for specified OreDictionary

### DIFF
--- a/src/main/java/vazkii/botania/common/lexicon/page/PagePetalRecipe.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PagePetalRecipe.java
@@ -80,6 +80,7 @@ public class PagePetalRecipe<T extends RecipePetals> extends PageRecipe {
 			Object input = obj;
 			if(input instanceof String) {
 				List<ItemStack> ores = OreDictionary.getOres((String) input);
+				if (ores.size() == 0) continue;
 				input = ores.get(oredictCounter % ores.size());
 			}
 


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9771