### PR TITLE
Fix recipe ordering

### DIFF
--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -443,8 +443,9 @@ public final class BotaniaAPI {
 	 * @see BotaniaAPI#registerManaInfusionRecipe
 	 */
 	public static RecipeManaInfusion registerManaAlchemyRecipe(ItemStack output, Object input, int mana) {
-		RecipeManaInfusion recipe = registerManaInfusionRecipe(output, input, mana);
+		RecipeManaInfusion recipe = new RecipeManaInfusion(output, input, mana);
 		recipe.setAlchemy(true);
+		manaInfusionRecipes.add(0, recipe);
 		return recipe;
 	}
 
@@ -454,8 +455,9 @@ public final class BotaniaAPI {
 	 * @see BotaniaAPI#registerManaInfusionRecipe
 	 */
 	public static RecipeManaInfusion registerManaConjurationRecipe(ItemStack output, Object input, int mana) {
-		RecipeManaInfusion recipe = registerManaInfusionRecipe(output, input, mana);
+		RecipeManaInfusion recipe = new RecipeManaInfusion(output, input, mana);
 		recipe.setConjuration(true);
+		manaInfusionRecipes.add(0, recipe);
 		return recipe;
 	}
 


### PR DESCRIPTION
Enforces sorting of catalyst-enabled recipes before non-catalyst options.

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9656