### PR TITLE
Remove the >127 potion limit for known bugfixing coremods

### DIFF
--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -351,7 +351,10 @@ public final class ConfigHandler {
 	private static void verifyPotionArray() {
 		if(Loader.isModLoaded("DragonAPI"))
 			potionArrayLimit = Potion.potionTypes.length;
-		else potionArrayLimit = 127;
+		else if(Loader.isModLoaded("hodgepodge"))
+			potionArrayLimit = 255;
+		else
+			potionArrayLimit = 127;
 
 		verifiedPotionArray = true;
 	}


### PR DESCRIPTION
Botania potions fix part 2/3 - see https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9568

- Checks if hodgepodge is installed, and if it does, assume it pushed the potion id limit to 255