### PR TITLE
Set harvest level for Terra Shatterer based on mana tier

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/ItemTerraPick.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/ItemTerraPick.java
@@ -205,6 +205,15 @@ public class ItemTerraPick extends ItemManasteelPick implements IManaItem, ISequ
 		return pass == 1 && isEnabled(stack) ? iconOverlay : isTipped(stack) ? iconTipped : iconTool;
 	}
 
+	@Override
+	public int getHarvestLevel(ItemStack stack, String toolClass) {
+		if (!"pickaxe".equals(toolClass)) {
+			return super.getHarvestLevel(stack, toolClass);
+		}
+		// Rank S -> level 8 (Manyullyn)
+		return getLevel(stack) + 4;
+	}
+
 	public static boolean isTipped(ItemStack stack) {
 		return ItemNBTHelper.getBoolean(stack, TAG_TIPPED, false);
 	}


### PR DESCRIPTION
level 4 for rank D, level 8 for rank S