### PR TITLE
Make default recipes enabled by default

### DIFF
--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -43,7 +43,7 @@ public final class ConfigHandler {
 
 	public static boolean useAdaptativeConfig = true;
 
-	public static boolean enableDefaultRecipes = false;
+	public static boolean enableDefaultRecipes = true;
 
 	public static boolean useShaders = true;
 	public static boolean lexiconRotatingItems = true;


### PR DESCRIPTION
As said in description of this option, this is expert option. And, i think, recipes should be enabled by default for non-expert users. Modpack author will disable it, if needed. But it will be hard for common user to adress why there are no recipes.