### PR TITLE
Make flowers enabled by default

### DIFF
--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -94,7 +94,7 @@ public final class ConfigHandler {
 	public static int harvestLevelWeight = 2;
 	public static int harvestLevelBore = 3;
 
-	public static int flowerQuantity = 0;
+	public static int flowerQuantity = 2;
 	public static int flowerDensity = 2;
 	public static int flowerPatchSize = 6;
 	public static int flowerPatchChance = 16;


### PR DESCRIPTION
PR like #21 but for flowers. This will helpful to players, who using this fork of botania outside of any modpacks. This will not affect GTNH modpack(and other modpacks) because they are alredy have Botania.cfg. Also in config descripton sayed that this option should be 2 by default: "The quantity of Botania flower patches to generate in the world, defaults to 2, the lower the number the less patches generate.".