### PR TITLE
Disabling smoky quartz

### DIFF
--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -81,7 +81,7 @@ public final class ConfigHandler {
 	public static boolean enderPickpocketEnabled = true;
 
 	public static boolean fallenKanadeEnabled = true;
-	public static boolean darkQuartzEnabled = true;
+	public static boolean darkQuartzEnabled = false;
 	public static boolean enchanterEnabled = true;
 	public static boolean fluxfieldEnabled = true;
 	public static boolean relicsEnabled = true;


### PR DESCRIPTION
Doing this from github online, in an airport right now.

Tinkerer generates the exact same quartz, the exact same blocks, all use the exact same texture (since you know, same dev) but we had already gregified tinkerer's recipe, not botania's, so as such, I thought it made more sense to just disable botania's, as vazkii seemed to indicate should be done via this config, than it does to oredict them all and all that, especially given that the tinkerer recipe produces 8x more quartz than botania.

This shouldn't cause any issues, unless Ender added a specifically botania based smoky quartz use to some random recipe for some reason, in which case, the change would be extremely simple to fix.

This change literally just disables Botania smokey quartz in config.