### PR TITLE
Ring of loki improvement

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,12 +5,12 @@ dependencies {
 
     compile('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
 
-    compileOnly('com.github.GTNewHorizons:Railcraft:9.13.6:api') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:Railcraft:9.14.0:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:StorageDrawers:1.11.13-GTNH:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.2.7:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.2.7-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.3.45-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.27:api') {transitive=false}
-    compile('com.github.GTNewHorizons:GTNHLib:0.0.4:dev')
+    compile('com.github.GTNewHorizons:GTNHLib:0.0.13:dev')
 
     compileOnly('curse.maven:cofh-lib-220333:2388748')
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,7 +14,5 @@ dependencies {
 
     compileOnly('curse.maven:cofh-lib-220333:2388748')
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150')
-
-    runtimeOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.42.72:dev')
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,4 +14,7 @@ dependencies {
 
     compileOnly('curse.maven:cofh-lib-220333:2388748')
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150')
+
+    runtimeOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.42.72:dev')
 }
+

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -144,12 +144,12 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 					Block markedBlock = player.worldObj.getBlock(x, y, z);
 					Boolean wasActivated = markedBlock.onBlockActivated(player.worldObj, x, y, z, player, lookPos.sideHit, hitX,hitY,hitZ);
 					
-					if(heldItemStack.stackSize == 0 ) {
+					if (heldItemStack.stackSize == 0 ) {
 						event.setCanceled(true);
 						recursion = false;
 						return;
 					}
-					if(!wasActivated){
+					if (!wasActivated) {
 						item.onItemUse(player.capabilities.isCreativeMode ? heldItemStack.copy() : heldItemStack, player, player.worldObj, x, y, z, lookPos.sideHit, (float) lookPos.hitVec.xCoord - x, (float) lookPos.hitVec.yCoord - y, (float) lookPos.hitVec.zCoord - z);						
 						if(heldItemStack.stackSize == 0) {
 							event.setCanceled(true);
@@ -157,7 +157,7 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 							return;
 						}
 					}
-					}
+				}
 			}
 			recursion = false;
 		}


### PR DESCRIPTION
Item and block interactions in minecraft have 2 sides, item side and block side, before ring of loki was only able to trigger action of item, now it will first try to trigger block activation, this can be useful when you want to configure a lot of ae2 components, or want to connect a lot of wires/pipes