### PR TITLE
Added GoG Skybox support for all dimensions

### DIFF
--- a/src/main/java/vazkii/botania/client/render/world/SkyblockRenderEvents.java
+++ b/src/main/java/vazkii/botania/client/render/world/SkyblockRenderEvents.java
@@ -16,13 +16,21 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.world.WorldTypeSkyblock;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import java.util.stream.IntStream;
 
 public final class SkyblockRenderEvents {
 
 	@SubscribeEvent
 	public void onRender(RenderWorldLastEvent event) {
 		World world = Minecraft.getMinecraft().theWorld;
-		if(ConfigHandler.enableFancySkybox && world.provider.dimensionId == 0 && (ConfigHandler.enableFancySkyboxInNormalWorlds || WorldTypeSkyblock.isWorldSkyblock(Minecraft.getMinecraft().theWorld))) {
+
+		boolean renderFancySkybox = ConfigHandler.enableFancySkybox && (
+				(ConfigHandler.enableFancySkyboxInNormalWorlds && (world.provider.dimensionId == 0) ) ||
+				(ConfigHandler.enableFancySkyboxInDimension && (IntStream.of(ConfigHandler.fancySkyboxDimension).anyMatch(x -> x == world.provider.dimensionId))) ||
+				(WorldTypeSkyblock.isWorldSkyblock(Minecraft.getMinecraft().theWorld))
+		);
+
+		if(renderFancySkybox) {
 			if(!(world.provider.getSkyRenderer() instanceof SkyblockSkyRenderer))
 				world.provider.setSkyRenderer(new SkyblockSkyRenderer());
 		}

--- a/src/main/java/vazkii/botania/client/render/world/SkyblockRenderEvents.java
+++ b/src/main/java/vazkii/botania/client/render/world/SkyblockRenderEvents.java
@@ -26,7 +26,7 @@ public final class SkyblockRenderEvents {
 
 		boolean renderFancySkybox = ConfigHandler.enableFancySkybox && (
 				(ConfigHandler.enableFancySkyboxInNormalWorlds && (world.provider.dimensionId == 0) ) ||
-				(ConfigHandler.enableFancySkyboxInDimension && (IntStream.of(ConfigHandler.fancySkyboxDimension).anyMatch(x -> x == world.provider.dimensionId))) ||
+				(ConfigHandler.enableFancySkyboxInDimension && ConfigHandler.fancySkyboxDimensions.contains(world.provider.dimensionId)) ||
 				(WorldTypeSkyblock.isWorldSkyblock(Minecraft.getMinecraft().theWorld))
 		);
 

--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -11,10 +11,13 @@
 package vazkii.botania.common.core.handler;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.potion.Potion;
@@ -67,7 +70,7 @@ public final class ConfigHandler {
 	public static boolean enableFancySkybox = true;
 	public static boolean enableFancySkyboxInNormalWorlds = false;
 	public static boolean enableFancySkyboxInDimension = false;
-	public static int[] fancySkyboxDimension = new int[]{};
+	public static HashSet<Integer> fancySkyboxDimensions = new HashSet<Integer>() {};
 	
 	public static int manaBarHeight = 29;
 	public static int flightBarHeight = 49;
@@ -204,7 +207,7 @@ public final class ConfigHandler {
 		enableFancySkyboxInDimension = loadPropBool("fancySkybox.customDim", desc, enableFancySkyboxInDimension);
 
 		desc = "The ID of the dimension to use";
-		fancySkyboxDimension = loadPropIntArray("fancySkybox.customDimID", desc, fancySkyboxDimension);
+		fancySkyboxDimensions = loadPropIntSet("fancySkybox.customDimID", desc, fancySkyboxDimensions);
 
 		desc = "The height of the mana display bar in above the XP bar. You can change this if you have a mod that changes where the XP bar is.";
 		manaBarHeight = loadPropInt("manaBar.height", desc, manaBarHeight);
@@ -370,6 +373,19 @@ public final class ConfigHandler {
 			adaptor.adaptPropertyIntArray(prop, prop.getIntList());
 
 		return prop.getIntList();
+	}
+
+	public static HashSet<Integer> loadPropIntSet(String propName, String desc, HashSet<Integer> intSet) {
+		int[] defaultValues = intSet.stream().mapToInt(Number::intValue).toArray();
+		Property prop = config.get(Configuration.CATEGORY_GENERAL, propName, defaultValues);
+		prop.comment = desc;
+
+		if(adaptor != null)
+			adaptor.adaptPropertyIntArray(prop, prop.getIntList());
+
+		return Arrays.stream(prop.getIntList())
+				.boxed()
+				.collect(Collectors.toCollection(HashSet::new));
 	}
 
 	public static int loadPropPotionId(String propName, int default_) {

--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -66,6 +66,8 @@ public final class ConfigHandler {
 	public static boolean enableArmorModels = true;
 	public static boolean enableFancySkybox = true;
 	public static boolean enableFancySkyboxInNormalWorlds = false;
+	public static boolean enableFancySkyboxInDimension = false;
+	public static int[] fancySkyboxDimension = new int[]{};
 	
 	public static int manaBarHeight = 29;
 	public static int flightBarHeight = 49;
@@ -197,7 +199,13 @@ public final class ConfigHandler {
 		
 		desc = "Set this to true to enable the fancy skybox in non Garden of Glass worlds. (Does not require Garden of Glass loaded to use, needs 'fancySkybox.enable' to be true as well)";
 		enableFancySkyboxInNormalWorlds = loadPropBool("fancySkybox.normalWorlds", desc, enableFancySkyboxInNormalWorlds);
-		
+
+		desc = "Set this to true to enable the fancy skybox in custom dimension. (Does not require Garden of Glass loaded to use, needs 'fancySkybox.enable' to be true as well)";
+		enableFancySkyboxInDimension = loadPropBool("fancySkybox.customDim", desc, enableFancySkyboxInDimension);
+
+		desc = "The ID of the dimension to use";
+		fancySkyboxDimension = loadPropIntArray("fancySkybox.customDimID", desc, fancySkyboxDimension);
+
 		desc = "The height of the mana display bar in above the XP bar. You can change this if you have a mod that changes where the XP bar is.";
 		manaBarHeight = loadPropInt("manaBar.height", desc, manaBarHeight);
 


### PR DESCRIPTION
- Added a boolean to toggle the feature to the config
- Added an int array to contain the dimension you would like to recieve the Skybox

- Changed the GoG Skybox render check to include above changes

Basically this allows you to display the Garden of Glass skybox in any dimension you wish, instead of just in the overworld. I like to use this to have the skybox in my personal void dimension.
