### PR TITLE
The ring of ikoL awakens!

### DIFF
--- a/src/main/java/vazkii/botania/api/item/IInWorldRenderable.java
+++ b/src/main/java/vazkii/botania/api/item/IInWorldRenderable.java
@@ -1,0 +1,13 @@
+package vazkii.botania.api.item;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+/**
+ * An item that implements this will allow some custom render. This will be called while the item is in the inventory,
+ * armor slot or bauble slots.
+ */
+public interface IInWorldRenderable
+{
+    public void renderInWorld(EntityPlayer player, ItemStack stack);
+}

--- a/src/main/java/vazkii/botania/client/core/handler/BoundTileRenderer.java
+++ b/src/main/java/vazkii/botania/client/core/handler/BoundTileRenderer.java
@@ -29,12 +29,17 @@ import org.lwjgl.opengl.GL11;
 
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.item.IExtendedWireframeCoordinateListProvider;
+import vazkii.botania.api.item.IInWorldRenderable;
 import vazkii.botania.api.item.IWireframeCoordinateListProvider;
 import vazkii.botania.api.wand.ICoordBoundItem;
 import vazkii.botania.api.wand.IWireframeAABBProvider;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public final class BoundTileRenderer {
+
+	public static int getWireframeColor(){
+		return Color.HSBtoRGB(ClientTickHandler.ticksInGame % 200 / 200F, 0.6F, 1F);
+	}
 
 	@SubscribeEvent
 	public void onWorldRenderLast(RenderWorldLastEvent event) {
@@ -49,7 +54,7 @@ public final class BoundTileRenderer {
 
 		EntityPlayer player = Minecraft.getMinecraft().thePlayer;
 		ItemStack stack = player.getCurrentEquippedItem();
-		int color = Color.HSBtoRGB(ClientTickHandler.ticksInGame % 200 / 200F, 0.6F, 1F);
+		int color = getWireframeColor();
 		if(stack != null && stack.getItem() instanceof ICoordBoundItem) {
 			ChunkCoordinates coords = ((ICoordBoundItem) stack.getItem()).getBinding(stack);
 			if(coords != null)
@@ -82,6 +87,11 @@ public final class BoundTileRenderer {
 						renderBlockOutlineAt(coords, color, 5F);
 				}
 			}
+			if(stackInSlot != null && stackInSlot.getItem() instanceof IInWorldRenderable) {
+				IInWorldRenderable provider = (IInWorldRenderable) stackInSlot.getItem();
+				provider.renderInWorld(player,stackInSlot);
+			}
+
 		}
 
 		GL11.glEnable(GL11.GL_DEPTH_TEST);

--- a/src/main/java/vazkii/botania/client/core/handler/KeyHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/KeyHandler.java
@@ -3,6 +3,7 @@ package vazkii.botania.client.core.handler;
 import net.minecraft.client.settings.KeyBinding;
 import vazkii.botania.common.network.PacketHandler;
 import vazkii.botania.common.network.PacketLokiClear;
+import vazkii.botania.common.network.PacketLokiMirror;
 import vazkii.botania.common.network.PacketLokiToggle;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -15,11 +16,13 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class KeyHandler {
     private static final KeyBinding keyToggleRingOfLoki= new KeyBinding("botaniamisc.toggleLoki", 0, "botaniamisc.keyCategory");
     private static final KeyBinding keyRingOfLokiClear= new KeyBinding("botaniamisc.ringOfLokiClear", 0, "botaniamisc.keyCategory");
+    private static final KeyBinding keyRingOfLokiMirror= new KeyBinding("botaniamisc.ringOfLokiMirror", 0, "botaniamisc.keyCategory");
 
     public KeyHandler() {
         FMLCommonHandler.instance().bus().register(this);
-        ClientRegistry.registerKeyBinding(keyToggleRingOfLoki);  
+        ClientRegistry.registerKeyBinding(keyToggleRingOfLoki);
         ClientRegistry.registerKeyBinding(keyRingOfLokiClear);
+        ClientRegistry.registerKeyBinding(keyRingOfLokiMirror);
 
     }
     @SideOnly(Side.CLIENT)
@@ -35,6 +38,9 @@ public class KeyHandler {
         if(keyRingOfLokiClear.isPressed()){
             ringOfLokiClear();
         }
+        if(keyRingOfLokiMirror.isPressed()){
+            toggleRingLokiMirroring();
+        }
     }
 
     private static void toggleRingLoki() {
@@ -43,5 +49,8 @@ public class KeyHandler {
 
     private static void ringOfLokiClear() {
         PacketHandler.INSTANCE.sendToServer(new PacketLokiClear());
+    }
+    private static void toggleRingLokiMirroring() {
+        PacketHandler.INSTANCE.sendToServer(new PacketLokiMirror());
     }
 }

--- a/src/main/java/vazkii/botania/common/core/helper/LokiCursor.java
+++ b/src/main/java/vazkii/botania/common/core/helper/LokiCursor.java
@@ -30,6 +30,15 @@ public class LokiCursor {
 
         return new LokiCursor(x,y,z,mirror);
     }
+    public static boolean isMirrorX(byte mirrorMode){
+        return (mirrorMode & xAxisBitmask) > 0;
+    }
+    public static boolean isMirrorY(byte mirrorMode){
+        return (mirrorMode & yAxisBitmask) > 0;
+    }
+    public static boolean isMirrorZ(byte mirrorMode){
+        return (mirrorMode & zAxisBitmask) > 0;
+    }
     public  NBTTagCompound toNBT() {
         NBTTagCompound cmp = new NBTTagCompound();
         cmp.setInteger(TAG_X_OFFSET, coordinates.posX);
@@ -55,13 +64,17 @@ public class LokiCursor {
         return coordinates;
     }
 
-    public boolean isXmirrored(){
-        return (mirrorMode & xAxisBitmask) > 0;
+    public boolean isMirrorX(){
+        return isMirrorX(mirrorMode);
     }
-    public boolean isYmirrored(){
-        return (mirrorMode & yAxisBitmask) > 0;
+    public boolean isMirrorY(){
+        return isMirrorY(mirrorMode);
     }
-    public boolean isZmirrored(){
-        return (mirrorMode & zAxisBitmask) > 0;
+    public boolean isMirrorZ(){
+        return isMirrorZ(mirrorMode);
+    }
+
+    public boolean isMirror(){
+        return mirrorMode!=0;
     }
 }

--- a/src/main/java/vazkii/botania/common/core/helper/LokiCursor.java
+++ b/src/main/java/vazkii/botania/common/core/helper/LokiCursor.java
@@ -1,0 +1,67 @@
+package vazkii.botania.common.core.helper;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ChunkCoordinates;
+
+
+public class LokiCursor {
+    private static final String TAG_X_OFFSET = "xOffset";
+    private static final String TAG_Y_OFFSET = "yOffset";
+    private static final String TAG_Z_OFFSET = "zOffset";
+    private static final String TAG_MIRROR_MODE = "mirror";
+
+    private static final byte xAxisBitmask = 4; //100
+    private static final byte yAxisBitmask = 2; //010
+    private static final byte zAxisBitmask = 1; //001
+
+    private byte mirrorMode;
+    private ChunkCoordinates coordinates;
+
+    public LokiCursor(int x, int y, int z, byte mode){
+        coordinates = new ChunkCoordinates(x,y,z);
+        mirrorMode = mode;
+    }
+
+    public static LokiCursor fromNBT(NBTTagCompound cmp){
+        int x = cmp.getInteger(TAG_X_OFFSET);
+        int y = cmp.getInteger(TAG_Y_OFFSET);
+        int z = cmp.getInteger(TAG_Z_OFFSET);
+        byte mirror = cmp.getByte(TAG_MIRROR_MODE);
+
+        return new LokiCursor(x,y,z,mirror);
+    }
+    public  NBTTagCompound toNBT() {
+        NBTTagCompound cmp = new NBTTagCompound();
+        cmp.setInteger(TAG_X_OFFSET, coordinates.posX);
+        cmp.setInteger(TAG_Y_OFFSET, coordinates.posY);
+        cmp.setInteger(TAG_Z_OFFSET, coordinates.posZ);
+        cmp.setInteger(TAG_MIRROR_MODE, mirrorMode);
+        return cmp;
+    }
+
+    public int getX(){
+        return coordinates.posX;
+    }
+
+    public int getY(){
+        return coordinates.posY;
+    }
+
+    public int getZ(){
+        return coordinates.posZ;
+    }
+
+    public ChunkCoordinates getCoordinates(){
+        return coordinates;
+    }
+
+    public boolean isXmirrored(){
+        return (mirrorMode & xAxisBitmask) > 0;
+    }
+    public boolean isYmirrored(){
+        return (mirrorMode & yAxisBitmask) > 0;
+    }
+    public boolean isZmirrored(){
+        return (mirrorMode & zAxisBitmask) > 0;
+    }
+}

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -154,6 +154,8 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 			double oldPosX = player.posX;
 			double oldPosY = player.posY;
 			double oldPosZ = player.posZ;
+			float oldPitch = player.rotationPitch;
+			float oldYaw = player.rotationYaw;
 
 			int masterOffsetX = lookPos.blockX - originCoords.posX;
 			int masterOffsetY = lookPos.blockY - originCoords.posY;
@@ -168,14 +170,21 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 				int x = lookPos.blockX + cursor.getX();
 				int y = lookPos.blockY + cursor.getY();
 				int z = lookPos.blockZ + cursor.getZ();
+				player.rotationYaw = oldYaw;
 				if(cursor.isXmirrored()){
 					x -= 2*masterOffsetX;
+					player.rotationYaw = 180 - (Math.abs(player.rotationYaw));
+					if(oldYaw < 0){
+						player.rotationYaw *= -1;
+					}
 				}
 				if(cursor.isYmirrored()){
 					y -= 2*masterOffsetY;
+					player.rotationPitch = oldPitch * (-1);
 				}
 				if(cursor.isZmirrored()){
 					z -= 2*masterOffsetZ;
+					player.rotationYaw = player.rotationYaw * (-1);
 				}
 
 				Item item = heldItemStack.getItem();
@@ -240,6 +249,8 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 			player.posX = oldPosX;
 			player.posY = oldPosY;
 			player.posZ = oldPosZ;
+			player.rotationPitch = oldPitch;
+			player.rotationYaw = oldYaw;
 		}
 	}
 	

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -116,8 +116,8 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 		MovingObjectPosition lookPos = ToolCommons.raytraceFromEntity(player.worldObj, player, true, 10F);
 		List<LokiCursor> cursors = getCursorList(lokiRing);
 		int cursorCount = cursors.size();
-
-		int cost = Math.min(cursorCount, (int) Math.pow(Math.E, cursorCount * 0.25));
+		//I don`t think mana for placing should be cruel , so I just made graph with funny line
+		int cost = (int)(50*Math.sin(0.04* cursorCount)+cursorCount+120+20*Math.cos(0.2*cursorCount));
 
 		if (heldItemStack == null && event.action == Action.RIGHT_CLICK_BLOCK && player.isSneaking() && isRingEnabled(lokiRing)) {
 			if(originCoords.posY == -1 && lookPos != null) {
@@ -365,6 +365,14 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 		if(lokiRing == null || player.worldObj.isRemote || !isRingEnabled(lokiRing) || !isRingBreakingEnabled(lokiRing))
 			return;
 		List<LokiCursor> cursors = getCursorList(lokiRing);
+		//In case someone wants to mine ore veins with loki, this should make 1 manapool worth of mana last for 2 veins
+		int cost = 30 * cursors.size();
+
+		if(!ManaItemHandler.requestManaExact(lokiRing, player, cost, true)){
+			renderHUDNotification(HUD_MESSAGE.INSUFFICIENT_MANA);
+			return;
+		}
+
 		ISequentialBreaker breaker  = null;
 		if(item instanceof ISequentialBreaker)
 			breaker = (ISequentialBreaker) item;

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -142,7 +142,7 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 							break addCursor;
 						}
 
-					addCursor(lokiRing, relX, relY, relZ, byte(0));
+					addCursor(lokiRing, relX, relY, relZ, (byte)0 );
 					if(player instanceof EntityPlayerMP)
 						PacketHandler.INSTANCE.sendTo(new PacketSyncBauble(player, slot), (EntityPlayerMP) player);
 				}

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -10,7 +10,8 @@
  */
 package vazkii.botania.common.item.relic;
 
-import java.awt.*;
+
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.List;
 import com.gtnewhorizon.gtnhlib.GTNHLib;

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -122,7 +122,6 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 		if (heldItemStack == null && event.action == Action.RIGHT_CLICK_BLOCK && player.isSneaking() && isRingEnabled(lokiRing)) {
 			if(originCoords.posY == -1 && lookPos != null) {
 				setOriginPos(lokiRing, lookPos.blockX, lookPos.blockY, lookPos.blockZ);
-				clearCursors(lokiRing);
 				if(player instanceof EntityPlayerMP)
 					PacketHandler.INSTANCE.sendTo(new PacketSyncBauble(player, slot), (EntityPlayerMP) player);
 			} else if(lookPos != null) {

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -28,7 +28,12 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.*;
+
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.ChunkCoordinates;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -569,11 +569,13 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 		return true;
 	}
 
+	@Override
 	@SideOnly(Side.CLIENT)
 	public void renderInWorld(EntityPlayer player, ItemStack stack){
 		renderMirrors(player,stack);
 	}
 
+	@SideOnly(Side.CLIENT)
 	private void renderMirrors(EntityPlayer player,ItemStack stack) {
 		ItemStack lokiRing = getLokiRing(player);
 		if(lokiRing != stack || !isRingEnabled(lokiRing) )

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -569,6 +569,7 @@ public class ItemLokiRing extends ItemRelicBauble implements IExtendedWireframeC
 		return true;
 	}
 
+	@SideOnly(Side.CLIENT)
 	public void renderInWorld(EntityPlayer player, ItemStack stack){
 		renderMirrors(player,stack);
 	}

--- a/src/main/java/vazkii/botania/common/network/PacketHandler.java
+++ b/src/main/java/vazkii/botania/common/network/PacketHandler.java
@@ -18,5 +18,7 @@ public class PacketHandler {
         INSTANCE.registerMessage(PacketLokiToggleBreakingAck.class, PacketLokiToggleBreakingAck.class, 3, Side.CLIENT);
         INSTANCE.registerMessage(PacketLokiClear.class, PacketLokiClear.class, 4, Side.SERVER);
         INSTANCE.registerMessage(PacketLokiClearAck.class, PacketLokiClearAck.class, 5, Side.CLIENT);
+        INSTANCE.registerMessage(PacketLokiMirror.class, PacketLokiMirror.class, 6, Side.SERVER);
+        INSTANCE.registerMessage(PacketLokiMirrorAck.class, PacketLokiMirrorAck.class, 7, Side.CLIENT);
     }
 }

--- a/src/main/java/vazkii/botania/common/network/PacketLokiMirror.java
+++ b/src/main/java/vazkii/botania/common/network/PacketLokiMirror.java
@@ -1,0 +1,34 @@
+package vazkii.botania.common.network;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import vazkii.botania.common.item.relic.ItemLokiRing;
+
+public class PacketLokiMirror implements IMessage, IMessageHandler<PacketLokiMirror, IMessage> {
+    @Override
+    public void fromBytes(ByteBuf byteBuf) {
+        // not needed
+    }
+
+    @Override
+    public void toBytes(ByteBuf byteBuf) {
+        // not needed
+    }
+
+    @Override
+    public IMessage onMessage(PacketLokiMirror message, MessageContext ctx) {
+        EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+        final ItemStack aRing = ItemLokiRing.getLokiRing(player);
+        if (aRing != null) {
+            byte mode = ItemLokiRing.getRingMirrorMode(aRing);
+            ItemLokiRing.setMirrorMode(aRing,(byte) ((mode+1)%8));
+            PacketLokiMirrorAck ackMessage = new PacketLokiMirrorAck();
+            PacketHandler.INSTANCE.sendTo(ackMessage, player);
+        }
+        return null;
+    }
+}

--- a/src/main/java/vazkii/botania/common/network/PacketLokiMirrorAck.java
+++ b/src/main/java/vazkii/botania/common/network/PacketLokiMirrorAck.java
@@ -1,0 +1,38 @@
+package vazkii.botania.common.network;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
+import net.minecraft.item.ItemStack;
+import vazkii.botania.common.item.relic.ItemLokiRing;
+
+public class PacketLokiMirrorAck implements IMessage, IMessageHandler<PacketLokiMirrorAck, IMessage> {
+
+    public boolean state;
+
+    @Override
+    public void fromBytes(ByteBuf byteBuf) {
+        state = byteBuf.readBoolean();
+    }
+
+    @Override
+    public void toBytes(ByteBuf byteBuf) {
+        byteBuf.writeBoolean(state);
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public IMessage onMessage(PacketLokiMirrorAck message, MessageContext ctx) {
+        Minecraft mc = Minecraft.getMinecraft();
+        final ItemStack aRing = ItemLokiRing.getLokiRing(mc.thePlayer) ;
+        if (aRing != null) {
+            ItemLokiRing.renderHUDNotification(ItemLokiRing.HUD_MESSAGE.MIRROR);
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/assets/botania/lang/en_US.lang
+++ b/src/main/resources/assets/botania/lang/en_US.lang
@@ -169,6 +169,7 @@ botaniamisc.lokiToggleDescription=Loki Switch Key to turn ring
 botaniamisc.lokiBreakingDescription=Loki Switch Key + Shift to toggle breaking
 botaniamisc.lokiCurrent=Current
 botaniamisc.lokiState=Ring
+botaniamisc.lokiMirror=Current mirror:
 
 # NEI INTEGRATION
 botania.nei.brewery=Botanical Brewery

--- a/src/main/resources/assets/botania/lang/en_US.lang
+++ b/src/main/resources/assets/botania/lang/en_US.lang
@@ -170,6 +170,7 @@ botaniamisc.lokiBreakingDescription=Loki Switch Key + Shift to toggle breaking
 botaniamisc.lokiCurrent=Current
 botaniamisc.lokiState=Ring
 botaniamisc.lokiMirror=Current mirror:
+botaniamisc.insufficient_mana=Not enough mana!
 
 # NEI INTEGRATION
 botania.nei.brewery=Botanical Brewery


### PR DESCRIPTION
Yet another PR aimed to improve our beloved friend, ring of Loki
Todays changes are


# Mirror mode! The long awaited feature
Want to build in 2 directions at once? Are you a fun of supersymetry? Than this feature is for you!

Now Ring of Loki will be able to place markers with mirrored side, the mirrored sides will have "X" drawn on it, a marker can mirror in multiple direction at once
### How to use it?
A new keybind will be added, it will toggle what marker will be placed next.
### How it works?
It "draws" symmetry axis(or point) between master block and each individual marker
Markers don`t influence each other, all that matters is relative position of you to master block
### Showcase
https://youtu.be/HUhiJwBX60Q
now, since master block position can matter, we have the following change

# Change to marker removal
Previously you could remove markers via keybind or by removing and placing back master marker.
The second option is now gone, instead of removing all markers, it now moves all markers together with master marker to desired location.

# My ring of loki doesn`t work! Help me!
A new notification added
![image](https://github.com/GTNewHorizons/Botania/assets/39595617/130e288a-09b1-4acb-8008-54b665becd0c)
Now ring will notify when you have not enough mana to break/place blocks

# Wow, its not free now. Or is it?
I believe ring of loki should not cost a lot of mana to run it.
Cost of Placing and Interacting was slightly increased and now features non monotonous growth in cost(funny line go brrr)
Breaking blocks now cost mana too! Its cost was balanced so it will take you 1 mana pools worth of mana to mine out 2 ore veins(3x3 chunks, 7 height), if someone actually decides to commit such madness

That`s all for today folks, stay tuned for next updates
## Huge thanks to:
notapenguin - Title of pr
c0bra5 - mirror suggestion that made me work more on this
