### PR TITLE
Added warpward as an allowed potion for the blood pendant

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,12 +5,12 @@ dependencies {
 
     compile('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
 
-    compileOnly('com.github.GTNewHorizons:Railcraft:9.15.5:api') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:Railcraft:9.15.6:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:StorageDrawers:1.13.3-GTNH:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.4.8:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.5.19-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.5.23-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.39:api') {transitive=false}
-    compile('com.github.GTNewHorizons:GTNHLib:0.2.7:dev')
+    compile('com.github.GTNewHorizons:GTNHLib:0.2.10:dev')
 
     compileOnly('curse.maven:cofh-lib-220333:2388748')
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150')

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.16'
 }
 
 

--- a/src/main/java/vazkii/botania/common/brew/ModBrews.java
+++ b/src/main/java/vazkii/botania/common/brew/ModBrews.java
@@ -74,6 +74,6 @@ public class ModBrews {
 			}
 
 		if(warpWardPotion != null)
-			warpWard = new BrewMod(LibBrewNames.WARP_WARD, 0xFBBDFF, 25000, new PotionEffect(warpWardPotion.id, 12000, 0)).setNotBloodPendantInfusable();
+			warpWard = new BrewMod(LibBrewNames.WARP_WARD, 0xFBBDFF, 25000, new PotionEffect(warpWardPotion.id, 12000, 0));
 	}
 }


### PR DESCRIPTION
I noticed in botania that there is a number of pedants for potion effects but none for warp ward. However, there are potions in botania for warp ward.

I have set the effect to be allowed to provide another option to deal with warp for players that also invest into the botania side of magic.

This pedant drains a constant amount of mana from the player which requires investment into botania to provide upkeep and does not remove warp from the player at all.