### PR TITLE
Shift for NEI Mana Bar (Lexicon Recipe Feature NEI Port)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,5 +14,6 @@ dependencies {
 
     compileOnly('curse.maven:cofh-lib-220333:2388748')
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150')
+    devOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.27-GTNH:dev')
 }
 

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -5,6 +5,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
@@ -49,6 +52,7 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 				otherStacks.add(new PositionedStack(new ItemStack(ModBlocks.conjurationCatalyst), 10, 37));
 
 			output = new PositionedStack(recipe.getOutput(), 101, 37);
+			// This value is where the mana bar is stored initially
 			mana = recipe.getManaToConsume();
 		}
 
@@ -94,9 +98,16 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 		super.drawBackground(recipe);
 		GL11.glEnable(GL11.GL_BLEND);
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
+		// Mana infusion is the mana pool, super weird.
 		GuiDraw.changeTexture(LibResources.GUI_MANA_INFUSION_OVERLAY);
 		GuiDraw.drawTexturedModalRect(45, 20, 38, 35, 92, 50);
-		HUDHandler.renderManaBar(32, 80, 0x0000FF, 0.75F, ((CachedManaPoolRecipe) arecipes.get(recipe)).mana, TilePool.MAX_MANA / 10);
+		// Below is where the mana bar actually drawn.
+		int tempMana = ((CachedManaPoolRecipe) arecipes.get(recipe)).mana;
+		HUDHandler.renderManaBar(32, 80, 0x0000FF, 0.75F, GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10, TilePool.MAX_MANA / 10);
+		FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+		String size = GuiScreen.isShiftKeyDown() ? "1x " : "10x ";
+		String localized = StatCollector.translateToLocal("botaniamisc.neiratio");
+		font.drawString(size + localized, 84 - font.getStringWidth(size + localized) / 2, 71, 0x000000);
 		RenderTilePool.forceMana = true;
 	}
 

--- a/src/main/resources/assets/botania/lang/en_US.lang
+++ b/src/main/resources/assets/botania/lang/en_US.lang
@@ -50,6 +50,7 @@ botaniamisc.clickToSee=Click to read
 botaniamisc.shiftToRemove=Shift-click to remove
 botaniamisc.clickToAdd=Add Bookmark
 botaniamisc.ratio=%sx Zoom (hover to zoom out)
+botaniamisc.neiratio=Zoom (shift to zoom out)
 botaniamisc.bottleTooltip=It has an acquired taste
 botaniamisc.coarseDirt0=Coarse Dirt, grass
 botaniamisc.coarseDirt1=won't grow on it


### PR DESCRIPTION
Counter-proposal to: https://github.com/GTNewHorizons/Botania/pull/52

# What does this feature do:
https://github.com/GTNewHorizons/Botania/assets/78517796/6ba1da9d-490b-4f82-a2bd-cb6f38ca2bd0

# Simply ports this feature from the lexicon: 
https://github.com/GTNewHorizons/Botania/assets/78517796/94b7dd90-8e2e-42a4-9b5f-57995fdffb1a

With one minor change: that being using shift instead of hovering, this was intentionally done since the original hover is entirely dependent on a rigid idea where the bar is located, which causes issues when you display more than one recipe.

# Does this work with multiple recipes at one then?
Sure does:

https://github.com/GTNewHorizons/Botania/assets/78517796/986253d6-9cc3-4581-9a53-e93aacc83447



No more need to worry about not being able to tell single pixels apart, now it's *extremely* clear!
Just like the base feature, this is toggled on by default, so no confusion necessary!

"But Alastor, if you care about maintaining the original design, then why is the text above the bar" NEI limitations baby, I had the choice to modify the position of everything to some concern of incompatibility in different screen sizes, or just put it above the bar and ensure it works with multiple recipes at once, Occam's razor.

"But why does it still say zoom out on 1x zoom?" To maintain the original's design, as shown above, the lexicon does the exact same, and since this is a port of that feature, I'm maintaining parity.

