### PR TITLE
Fix music disk use in the GT electric jukebox by adding metadata

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,16 +1,16 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:Baubles:1.0.4:dev')
+    api('com.github.GTNewHorizons:Baubles:1.0.4:dev')
 
-    compile('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
+    api('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
 
     compileOnly('com.github.GTNewHorizons:Railcraft:9.15.15:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:StorageDrawers:2.0.5-GTNH:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.5.0:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.6.50-GTNH:dev')
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.39:api') {transitive=false}
-    compile('com.github.GTNewHorizons:GTNHLib:0.5.21:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.5.22:dev')
 
     compileOnly('curse.maven:cofh-lib-220333:2388748')
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150')

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,10 +50,10 @@ enableGenericInjection = false
 # Generate a class with a String field for the mod version named as defined below.
 # If generateGradleTokenClass is empty or not missing, no such class will be generated.
 # If gradleTokenVersion is empty or missing, the field will not be present in the class.
-generateGradleTokenClass =
+generateGradleTokenClass = vazkii.botania.common.Tags
 
 # Name of the token containing the project's current version to generate/replace.
-gradleTokenVersion = GRADLETOKEN_VERSION
+gradleTokenVersion = VERSION
 
 # [DEPRECATED] Mod ID replacement token.
 gradleTokenModId =
@@ -70,7 +70,7 @@ gradleTokenGroupName =
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...]).
 # Leave these properties empty to skip individual token replacements.
-replaceGradleTokenInFile = LibMisc.java
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.

--- a/src/main/java/vazkii/botania/common/item/record/ItemModRecord.java
+++ b/src/main/java/vazkii/botania/common/item/record/ItemModRecord.java
@@ -21,8 +21,9 @@ import vazkii.botania.common.core.BotaniaCreativeTab;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import com.gtnewhorizon.gtnhlib.api.MusicRecordMetadataProvider;
 
-public class ItemModRecord extends ItemRecord {
+public class ItemModRecord extends ItemRecord implements MusicRecordMetadataProvider {
 
 	private final String file;
 
@@ -55,4 +56,11 @@ public class ItemModRecord extends ItemRecord {
 		return new ResourceLocation(file);
 	}
 
+	@Override
+	public ResourceLocation getMusicRecordResource(ItemStack stack) {
+		if (stack == null || !(stack.getItem() instanceof ItemModRecord)) {
+			return null;
+		}
+		return new ResourceLocation(file);
+	}
 }

--- a/src/main/java/vazkii/botania/common/lib/LibMisc.java
+++ b/src/main/java/vazkii/botania/common/lib/LibMisc.java
@@ -11,14 +11,15 @@
 package vazkii.botania.common.lib;
 
 import net.minecraftforge.common.util.ForgeDirection;
+import vazkii.botania.common.Tags;
 
 public final class LibMisc {
 
 	// Mod Constants
 	public static final String MOD_ID = "Botania";
 	public static final String MOD_NAME = MOD_ID;
-	public static final String VERSION = "GRADLETOKEN_VERSION";
-	public static final String DEPENDENCIES = "required-after:Baubles;after:Thaumcraft";
+	public static final String VERSION = Tags.VERSION;
+	public static final String DEPENDENCIES = "required-after:Baubles;after:Thaumcraft;required-after:gtnhlib@[0.5.22,)";
 
 	// Network Contants
 	public static final String NETWORK_CHANNEL = MOD_ID;

--- a/src/main/resources/soundmeta/durations.json
+++ b/src/main/resources/soundmeta/durations.json
@@ -1,0 +1,6 @@
+{
+  "soundDurationsMs": {
+    "botania:music.gaia1": 202498,
+    "botania:music.gaia2": 226995
+  }
+}


### PR DESCRIPTION
- Clean up deprecated gradle settings
- Make dependency on gtnhlib explicit in the mod metadata (it was already there, just not in metadata)
- Add the metadata required to play music disks from Botania in the GT Electric Jukebox

Tested locally with a GT5 build making use of the gtnhlib API