### PR TITLE
Add configurable F3 Debug

### DIFF
--- a/src/main/java/vazkii/botania/client/core/handler/DebugHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/DebugHandler.java
@@ -35,7 +35,7 @@ public final class DebugHandler {
 	@SubscribeEvent
 	public void onDrawDebugText(RenderGameOverlayEvent.Text event) {
 		World world = Minecraft.getMinecraft().theWorld;
-		if(Minecraft.getMinecraft().gameSettings.showDebugInfo) {
+		if(Minecraft.getMinecraft().gameSettings.showDebugInfo && ConfigHandler.showF3Debug) {
 			event.left.add(null);
 			String version = LibMisc.VERSION;
 			if(version.contains("GRADLE"))

--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -48,6 +48,8 @@ public final class ConfigHandler {
 
 	public static boolean enableDefaultRecipes = true;
 
+	public static boolean showF3Debug = true;
+
 	public static boolean useShaders = true;
 	public static boolean lexiconRotatingItems = true;
 	public static boolean lexiconJustifiedText = false;
@@ -209,6 +211,9 @@ public final class ConfigHandler {
 
 		desc = "The ID of the dimension to use";
 		fancySkyboxDimensions = loadPropIntSet("fancySkybox.customDimID", desc, fancySkyboxDimensions);
+
+		desc = "Turn on or off the debug info in the F3 screen ingame";
+		showF3Debug = loadPropBool("showF3Debug", desc, showF3Debug);
 
 		desc = "The height of the mana display bar in above the XP bar. You can change this if you have a mod that changes where the XP bar is.";
 		manaBarHeight = loadPropInt("manaBar.height", desc, manaBarHeight);


### PR DESCRIPTION
Adds a config option that can disable or enable the F3 debug info as there wasn't any before and it takes up a lot of space and is quite useless!