### PR TITLE
Add Botania Multiblocks to StructureLib

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,5 +12,7 @@ dependencies {
     compileOnly('curse.maven:cofh-lib-220333:2388748')
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150')
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
+
+    compileOnly("com.github.GTNewHorizons:StructureLib:1.4.12:dev")
 }
 

--- a/src/main/java/vazkii/botania/api/lexicon/multiblock/compat/MultiblockCompatRegistry.java
+++ b/src/main/java/vazkii/botania/api/lexicon/multiblock/compat/MultiblockCompatRegistry.java
@@ -1,0 +1,224 @@
+package vazkii.botania.api.lexicon.multiblock.compat;
+
+import com.gtnewhorizon.structurelib.alignment.constructable.IMultiblockInfoContainer;
+import com.gtnewhorizon.structurelib.alignment.enumerable.ExtendedFacing;
+import com.gtnewhorizon.structurelib.structure.IStructureDefinition;
+import com.gtnewhorizon.structurelib.structure.ISurvivalBuildEnvironment;
+import com.gtnewhorizon.structurelib.structure.StructureDefinition;
+import com.gtnewhorizon.structurelib.structure.StructureUtility;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChunkCoordinates;
+import vazkii.botania.api.lexicon.multiblock.Multiblock;
+import vazkii.botania.api.lexicon.multiblock.component.MultiblockComponent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Automatically register any Botania Multiblock
+ */
+public class MultiblockCompatRegistry {
+
+    public static <T extends TileEntity> void registerMultiblock(
+            Multiblock mb, Class<T> controllerTileClass,
+            Block controllerBlock,
+            MultiblockComponent... extra
+    ) {
+        List<MultiblockComponent> components = mb.getComponents();
+        if (extra.length != 0) {
+            components = new ArrayList<>(components);
+            Collections.addAll(components, extra);
+        }
+
+        Map<Integer, RawStructureData> structureDataMap = new HashMap<>();
+        int min_x = Integer.MAX_VALUE, max_x = Integer.MIN_VALUE;
+        int min_y = Integer.MAX_VALUE, max_y = Integer.MIN_VALUE;
+        int min_z = Integer.MAX_VALUE, max_z = Integer.MIN_VALUE;
+
+        char ch = 'a';
+        for (MultiblockComponent component : components) {
+            int hash = getHash(component.getBlock(), component.getMeta());
+            ChunkCoordinates pos = component.getRelativePosition();
+            RawStructureData structureData = structureDataMap.get(hash);
+            if (structureData == null) {
+                List<ChunkCoordinates> coordinates = new ArrayList<>();
+                structureData = new RawStructureData(
+                        coordinates,
+                        component.getBlock(),
+                        component.getMeta(),
+                        ch++
+                );
+                structureDataMap.put(hash, structureData);
+            }
+            structureData.getPositions().add(pos);
+
+            min_x = Math.min(min_x, pos.posX); max_x = Math.max(max_x, pos.posX);
+            min_y = Math.min(min_y, pos.posY); max_y = Math.max(max_y, pos.posY);
+            min_z = Math.min(min_z, pos.posZ); max_z = Math.max(max_z, pos.posZ);
+        }
+
+        int x_size = max_x - min_x + 1;
+        int y_size = max_y - min_y + 1;
+        int z_size = max_z - min_z + 1;
+
+        //Data is saved in [z][y][x] format
+        String[][] stringData = new String[z_size][y_size];
+
+        char[] buffer = new char[x_size];
+        Arrays.fill(buffer, ' ');
+        //Since Strings and their content are immutable, this is fine.
+        String filledWithSpaces = new String(buffer);
+        for (int z = 0; z < z_size; z++) {
+            for (int y = 0; y < y_size; y++) {
+                stringData[z][y] = filledWithSpaces;
+            }
+        }
+
+        int controller_x = 0, controller_y = 0, controller_z = 0;
+        StringBuilder builder = new StringBuilder(x_size);
+        for (RawStructureData data : structureDataMap.values()) {
+            for (ChunkCoordinates pos : data.getPositions()) {
+                int x = pos.posX - min_x;
+                int z = pos.posZ - min_z;
+                //Data has to get flipped
+                int y = (stringData[z].length - 1) - (pos.posY - min_y);
+
+                if (data.getBlock() == controllerBlock) {
+                    controller_x = x;
+                    controller_y = y;
+                    controller_z = z;
+                }
+
+                String s = stringData[z][y];
+                builder.append(s);
+                builder.setCharAt(x, data.getBlockIdentifier());
+                stringData[z][y] = builder.toString();
+                builder.setLength(0);
+            }
+        }
+
+        StructureDefinition.Builder<? super T> structureBuilder = IStructureDefinition.builder()
+                .addShape("main", stringData);
+
+        for (RawStructureData data : structureDataMap.values()) {
+            structureBuilder.addElement(
+                    data.getBlockIdentifier(),
+                    StructureUtility.ofBlock(
+                            data.getBlock(),
+                            data.getMetadata()
+                    )
+            );
+        }
+
+        IMultiblockInfoContainer.registerTileClass(
+                controllerTileClass,
+                new BotaniaMultiblockInfoContainer<>(
+                        structureBuilder.build(),
+                        controller_x,
+                        controller_y,
+                        controller_z
+                )
+        );
+    }
+
+    private static int getHash(Block block, int metadata) {
+        return block.hashCode() * 31 + metadata;
+    }
+
+
+    private static class BotaniaMultiblockInfoContainer<T extends TileEntity> implements IMultiblockInfoContainer<T> {
+
+        private final IStructureDefinition<? super T> structure;
+        private final int x_offset, y_offset, z_offset;
+
+        public BotaniaMultiblockInfoContainer(
+                IStructureDefinition<? super T> structure,
+                int x_offset, int y_offset, int z_offset
+        ) {
+            this.structure = structure;
+            this.x_offset = x_offset;
+            this.y_offset = y_offset;
+            this.z_offset = z_offset;
+        }
+
+        @Override
+        public void construct(ItemStack stackSize, boolean hintsOnly, T tileEntity, ExtendedFacing aSide) {
+            structure.buildOrHints(
+                    tileEntity,
+                    stackSize,
+                    "main",
+                    tileEntity.getWorldObj(),
+                    aSide,
+                    tileEntity.xCoord,
+                    tileEntity.yCoord,
+                    tileEntity.zCoord,
+                    x_offset,
+                    y_offset,
+                    z_offset,
+                    hintsOnly
+            );
+        }
+
+        @Override
+        public int survivalConstruct(ItemStack stackSize, int elementBudge, ISurvivalBuildEnvironment env, T tileEntity, ExtendedFacing aSide) {
+            return structure.survivalBuild(
+                    tileEntity,
+                    stackSize,
+                    "main",
+                    tileEntity.getWorldObj(),
+                    aSide,
+                    tileEntity.xCoord,
+                    tileEntity.yCoord,
+                    tileEntity.zCoord,
+                    x_offset,
+                    y_offset,
+                    z_offset,
+                    elementBudge,
+                    env,
+                    false
+            );
+        }
+
+        @Override
+        public String[] getDescription(ItemStack stackSize) {
+            return new String[0];
+        }
+    }
+
+    private static class RawStructureData {
+        private final List<ChunkCoordinates> positions;
+        private final char identifier;
+        private final Block block;
+        private final int metadata;
+
+        public RawStructureData(List<ChunkCoordinates> positions, Block block, int metadata, char identifier) {
+            this.positions = positions;
+            this.identifier = identifier;
+            this.block = block;
+            this.metadata = metadata;
+        }
+
+        public Block getBlock() {
+            return block;
+        }
+
+        public int getMetadata() {
+            return metadata;
+        }
+
+        public List<ChunkCoordinates> getPositions() {
+            return positions;
+        }
+
+        public char getBlockIdentifier() {
+            return identifier;
+        }
+    }
+}

--- a/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
@@ -116,7 +116,7 @@ public class TileAlfPortal extends TileMod {
 		mb.addComponent(0, 1, 0, ModBlocks.alfPortal, 0);
 		mb.setRenderOffset(0, -1, 0);
 
-		return mb.makeSet();
+		return mb.makeSetRegisterStructure(TileAlfPortal.class, ModBlocks.alfPortal);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/tile/TileTerraPlate.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileTerraPlate.java
@@ -57,7 +57,7 @@ public class TileTerraPlate extends TileMod implements ISparkAttachable {
 		mb.addComponent(0, 1, 0, ModBlocks.terraPlate, 0);
 		mb.setRenderOffset(0, 1, 0);
 
-		return mb.makeSet();
+		return mb.makeSetRegisterStructure(TileTerraPlate.class, ModBlocks.terraPlate);
 	}
 
 	@Override

--- a/src/main/resources/assets/botania/lang/en_US.lang
+++ b/src/main/resources/assets/botania/lang/en_US.lang
@@ -650,6 +650,7 @@ tile.botania:flower12.name=Mystical Brown Flower
 tile.botania:flower13.name=Mystical Green Flower
 tile.botania:flower14.name=Mystical Red Flower
 tile.botania:flower15.name=Mystical Black Flower
+tile.botania:flower_structurelib.name=Any Botania Flower
 tile.botania:altar0.name=Petal Apothecary
 tile.botania:altar1.name=Forest Petal Apothecary
 tile.botania:altar2.name=Plains Petal Apothecary


### PR DESCRIPTION
Adds StructureLib multiblock previews from botania (previously, only BH multiblocks were added to StructureLib)

<img width="711" height="891" alt="2025-07-24_06 38 40" src="https://github.com/user-attachments/assets/869e650f-d9cf-4974-8cc5-fd98063d99d1" />
<img width="807" height="867" alt="2025-07-24_06 38 57" src="https://github.com/user-attachments/assets/b5fa0fc2-771e-4871-927e-b264b0bb7e40" />
<img width="756" height="850" alt="2025-07-24_06 39 24" src="https://github.com/user-attachments/assets/493324f4-a5ba-4400-8ab7-37683c1cc0ce" />
