### PR TITLE
Fix WAILA not displaying quartz pillar block name when placed on its side

### DIFF
--- a/src/main/java/vazkii/botania/common/item/block/ItemBlockSpecialQuartz.java
+++ b/src/main/java/vazkii/botania/common/item/block/ItemBlockSpecialQuartz.java
@@ -28,7 +28,8 @@ public class ItemBlockSpecialQuartz extends ItemMultiTexture {
 
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack) {
-		return par1ItemStack.getItemDamage() >= 3 ? "" : ((BlockSpecialQuartz) field_150939_a).getNames()[par1ItemStack.getItemDamage()];
+        String[] names = ((BlockSpecialQuartz) field_150939_a).getNames();
+		return par1ItemStack.getItemDamage() >= names.length ? ((BlockSpecialQuartz) field_150939_a).getNames()[names.length - 1] : ((BlockSpecialQuartz) field_150939_a).getNames()[par1ItemStack.getItemDamage()];
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/block/ItemBlockSpecialQuartz.java
+++ b/src/main/java/vazkii/botania/common/item/block/ItemBlockSpecialQuartz.java
@@ -29,7 +29,7 @@ public class ItemBlockSpecialQuartz extends ItemMultiTexture {
 	@Override
 	public String getUnlocalizedName(ItemStack par1ItemStack) {
         String[] names = ((BlockSpecialQuartz) field_150939_a).getNames();
-		return par1ItemStack.getItemDamage() >= names.length ? ((BlockSpecialQuartz) field_150939_a).getNames()[names.length - 1] : ((BlockSpecialQuartz) field_150939_a).getNames()[par1ItemStack.getItemDamage()];
+        return par1ItemStack.getItemDamage() >= names.length ? names[names.length - 1] : names[par1ItemStack.getItemDamage()];
 	}
 
 	@Override


### PR DESCRIPTION
The `getUnlocalizedName()` call for the quartz items will return blank if the damage value of the item stack is >= 3 and the sideways versions of the pillars have a damage value of 3 and 4.

I've made it so that if the damage value is greater than the number of lang entries returned by `getNames()` then it just returns the last entry in list which for all quartz blocks is the pillar since they're all registered in the same class.

This fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20879

Screenshot of fix:

<img width="1304" height="1217" alt="2025-08-19 16_29_39-Minecraft 1 7 10" src="https://github.com/user-attachments/assets/2bb15d37-a7f8-4a46-956a-12fd6e2d622d" />