### PR TITLE
Revert "Prevent overenchanting (#98)"

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/TileEnchanter.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileEnchanter.java
@@ -279,10 +279,8 @@ public class TileEnchanter extends TileMod implements ISparkAttachable {
 		case 3 : { // Enchant
 			if(stageTicks >= 100) {
 				for(EnchantmentData data : enchants)
-					if(EnchantmentHelper.getEnchantmentLevel(data.enchant, itemToEnchant) == 0) {
-                        Enchantment ench = Enchantment.enchantmentsList[data.enchant];
-						itemToEnchant.addEnchantment(ench, Math.min(data.level, ench.getMaxLevel()));
-                    }
+					if(EnchantmentHelper.getEnchantmentLevel(data.enchant, itemToEnchant) == 0)
+						itemToEnchant.addEnchantment(Enchantment.enchantmentsList[data.enchant], data.level);
 
 				enchants.clear();
 				manaRequired = -1;


### PR DESCRIPTION
This reverts commit 9157df8e3bd260658561d831295659fe52bb80ea.

This is a feature, not a bug. It's possible to get enchanted books over the normal "max" from other mods like Extra Utilities unstable tools made with Mobius ingots, and they should be usable. IMO, *anvils* are what need to be fixed (in hodgepodge) so you don't need to do weird workarounds to apply enchants that are possible to get as books.

If you still want to break functionality like this for an *actively supported mod*, it should at least be behind a config that is off by default.