### PR TITLE
Modify line-breaking method for rendering fonts in PageText

### DIFF
--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexicon.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexicon.java
@@ -284,7 +284,7 @@ public class GuiLexicon extends GuiScreen {
 		boolean unicode = fontRendererObj.getUnicodeFlag();
 		fontRendererObj.setUnicodeFlag(true);
 
-		PageText.renderText(x + 5, y - 3, 92, 120, 0, noteDisplay);
+		PageText.renderText(x + 5, y - 3, 92, 0, noteDisplay);
 		fontRendererObj.setUnicodeFlag(unicode);
 	}
 

--- a/src/main/java/vazkii/botania/common/lexicon/page/PageText.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageText.java
@@ -75,6 +75,10 @@ public class PageText extends LexiconPage {
 		font.setUnicodeFlag(unicode);
 	}
 
+	/**
+	 * Checks if the given character belongs to the CJK (Chinese, Japanese, Korean) Unicode block.
+	 * Used to handle proper line breaking for languages without spaces.
+	 */
 	public static boolean isCJK(char c) {
 		Character.UnicodeBlock block = Character.UnicodeBlock.of(c);
 		return block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS


### PR DESCRIPTION
Not all languages have been checked, so it may require native speakers to review them for possible grammatical issues

This PR is mainly for translation purposes, because the Botania handbook requires adding a space every 13 characters, which is not very user-friendly for translation

~~For certain languages, the space-based line break function has been retained, while other features remain unchanged~~

Resolved

<img width="1036" height="1293" alt="58c88c5edc9ecfebc2fde7bbaf6cd733" src="https://github.com/user-attachments/assets/c7baf9f3-e8dc-4072-9062-26c76745c163" />
<img width="915" height="1113" alt="4d5c9abd124802ea94e101bb0d170c39" src="https://github.com/user-attachments/assets/a776529e-a9d1-4446-bf04-7d2c6843e6a7" />
<img width="935" height="1190" alt="12e6deea19cfb3e2209dbd6962641104" src="https://github.com/user-attachments/assets/165991d4-fdb7-4f34-b715-c8cd029e464b" />
<img width="987" height="1224" alt="b11a4710b15cf8595d2640ee56009573" src="https://github.com/user-attachments/assets/583af052-557c-4c99-bdd3-bc84441e2573" />
