### PR TITLE
Allow Timeless Ivy to work on items in bauble slots

### DIFF
--- a/src/main/java/vazkii/botania/common/item/ItemRegenIvy.java
+++ b/src/main/java/vazkii/botania/common/item/ItemRegenIvy.java
@@ -47,8 +47,12 @@ public class ItemRegenIvy extends ItemMod {
             if (canBeRepaired(event, stack)) stack.setItemDamage(stack.getItemDamage() - 1);
         }
 
-		for (ItemStack bauble : PlayerHandler.getPlayerBaubles(event.player).stackList) {
-			if (canBeRepaired(event, bauble)) bauble.setItemDamage(bauble.getItemDamage() - 1);
+        ItemStack[] baubles = PlayerHandler.getPlayerBaubles(event.player).stackList;
+		if (baubles != null) {
+			for (int i = 0; i < baubles.length; i++) { // Basic for loop to avoid iterator in onTick method
+				ItemStack bauble = baubles[i];
+				if (canBeRepaired(event, bauble)) bauble.setItemDamage(bauble.getItemDamage() - 1);
+			}
 		}
     }
 

--- a/src/main/java/vazkii/botania/common/item/ItemRegenIvy.java
+++ b/src/main/java/vazkii/botania/common/item/ItemRegenIvy.java
@@ -10,6 +10,7 @@
  */
 package vazkii.botania.common.item;
 
+import baubles.common.lib.PlayerHandler;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.RecipeSorter;
 import net.minecraftforge.oredict.RecipeSorter.Category;
@@ -37,12 +38,22 @@ public class ItemRegenIvy extends ItemMod {
 	}
 
 	public void onTick(PlayerTickEvent event) {
-		if(event.phase == Phase.END && !event.player.worldObj.isRemote)
-			for(int i = 0; i < event.player.inventory.getSizeInventory(); i++) {
-				ItemStack stack = event.player.inventory.getStackInSlot(i);
-				if(stack != null && ItemNBTHelper.detectNBT(stack) && ItemNBTHelper.getBoolean(stack, TAG_REGEN, false) && stack.getItemDamage() > 0 && ManaItemHandler.requestManaExact(stack, event.player, MANA_PER_DAMAGE, true))
-					stack.setItemDamage(stack.getItemDamage() - 1);
-			}
+        if (event.phase != Phase.END || event.player.worldObj.isRemote) {
+            return;
+        }
+
+        for (int i = 0; i < event.player.inventory.getSizeInventory(); i++) {
+            ItemStack stack = event.player.inventory.getStackInSlot(i);
+            if (canBeRepaired(event, stack)) stack.setItemDamage(stack.getItemDamage() - 1);
+        }
+
+		for (ItemStack bauble : PlayerHandler.getPlayerBaubles(event.player).stackList) {
+			if (canBeRepaired(event, bauble)) bauble.setItemDamage(bauble.getItemDamage() - 1);
+		}
+    }
+
+	private static boolean canBeRepaired(PlayerTickEvent event, ItemStack stack) {
+		return stack != null && ItemNBTHelper.detectNBT(stack) && ItemNBTHelper.getBoolean(stack, TAG_REGEN, false) && stack.getItemDamage() > 0 && ManaItemHandler.requestManaExact(stack, event.player, MANA_PER_DAMAGE, true);
 	}
 
 	public class EventHandler {


### PR DESCRIPTION
Timeless Ivy allows items to be repaired with mana (like gear made from mana materials) at the cost of three of the item's anvil material in the crafting grid when the item is worn as armor or is anywhere in the inventory. This PR lets it operate on items in any bauble slot.