### PR TITLE
Add ability to consume GT Food to Gourmaryllis

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,6 +16,6 @@ dependencies {
 
 
     compileOnly("com.github.GTNewHorizons:StructureLib:1.4.32:dev")
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.324:dev")
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.362:dev")
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,5 +16,6 @@ dependencies {
 
 
     compileOnly("com.github.GTNewHorizons:StructureLib:1.4.32:dev")
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.324:dev")
 }
 

--- a/src/main/java/vazkii/botania/api/lexicon/multiblock/compat/GTFoodHelper.java
+++ b/src/main/java/vazkii/botania/api/lexicon/multiblock/compat/GTFoodHelper.java
@@ -1,0 +1,20 @@
+package vazkii.botania.common.block.subtile.generating.compat;
+
+import net.minecraft.item.ItemStack;
+
+import gregtech.api.interfaces.IFoodStat;
+import gregtech.api.items.MetaGeneratedItem;
+
+public class GTFoodHelper {
+
+    public static int getFoodHungerValue(ItemStack stack) {
+        if (!(stack.getItem() instanceof MetaGeneratedItem)) return -1;
+
+        MetaGeneratedItem metaItem = (MetaGeneratedItem) stack.getItem();
+        IFoodStat foodStat = metaItem.mFoodStats.get((short) stack.getItemDamage());
+        if (foodStat == null) return -1;
+
+        int hungerValue = foodStat.getFoodLevel(metaItem, stack, null);
+        return hungerValue > 0 ? hungerValue : -1;
+    }
+}

--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -43,6 +43,7 @@ public class Botania {
 	public static boolean etFuturumLoaded = false;
 	public static boolean storageDrawersLoaded = false;
 	public static boolean structureLibLoaded = false;
+	public static boolean gt5Loaded = false;
 
 	public static ILightHelper lightHelper;
 
@@ -63,6 +64,7 @@ public class Botania {
 		etFuturumLoaded = Loader.isModLoaded("etfuturum");
 		storageDrawersLoaded = Loader.isModLoaded("StorageDrawers");
 		structureLibLoaded = Loader.isModLoaded("structurelib");
+		gt5Loaded = Loader.isModLoaded("gregtech");
 		
 		lightHelper = coloredLightsLoaded ? new LightHelperColored() : new LightHelperVanilla();
 		proxy.preInit(event);

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileGourmaryllis.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileGourmaryllis.java
@@ -35,20 +35,20 @@ public class SubTileGourmaryllis extends SubTileGenerating {
 	int storedMana = 0;
 
 	private int getFoodHungerValue(ItemStack stack) {
-    if (stack == null) return -1;
+    	if (stack == null) return -1;
 
-    // Vanilla food
-    if (stack.getItem() instanceof ItemFood) {
-        return ((ItemFood) stack.getItem()).func_150905_g(stack);
-    }
+    	// Vanilla food
+    	if (stack.getItem() instanceof ItemFood) {
+        	return ((ItemFood) stack.getItem()).func_150905_g(stack);
+    	}
 
-    // GregTech food
-    if (Botania.gt5Loaded) {
-        return GTFoodHelper.getFoodHungerValue(stack);
-    }
+    	// GregTech food
+    	if (Botania.gt5Loaded) {
+        	return GTFoodHelper.getFoodHungerValue(stack);
+    	}
 
-    return -1;
-}
+    	return -1;
+	}
 
 	@Override
 	public void onUpdate() {

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileGourmaryllis.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileGourmaryllis.java
@@ -22,14 +22,33 @@ import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileGenerating;
 import vazkii.botania.common.lexicon.LexiconData;
+import vazkii.botania.common.Botania;
+import vazkii.botania.common.block.subtile.generating.compat.GTFoodHelper;
 
 public class SubTileGourmaryllis extends SubTileGenerating {
 
 	private static final String TAG_COOLDOWN = "cooldown";
+	private static final String TAG_STORED_MANA = "storedMana";
 	private static final int RANGE = 1;
 
 	int cooldown = 0;
 	int storedMana = 0;
+
+	private int getFoodHungerValue(ItemStack stack) {
+    if (stack == null) return -1;
+
+    // Vanilla food
+    if (stack.getItem() instanceof ItemFood) {
+        return ((ItemFood) stack.getItem()).func_150905_g(stack);
+    }
+
+    // GregTech food
+    if (Botania.gt5Loaded) {
+        return GTFoodHelper.getFoodHungerValue(stack);
+    }
+
+    return -1;
+}
 
 	@Override
 	public void onUpdate() {
@@ -49,28 +68,28 @@ public class SubTileGourmaryllis extends SubTileGenerating {
 		List<EntityItem> items = supertile.getWorldObj().getEntitiesWithinAABB(EntityItem.class, AxisAlignedBB.getBoundingBox(supertile.xCoord - RANGE, supertile.yCoord - RANGE, supertile.zCoord - RANGE, supertile.xCoord + RANGE + 1, supertile.yCoord + RANGE + 1, supertile.zCoord + RANGE + 1));
 		for(EntityItem item : items) {
 			ItemStack stack = item.getEntityItem();
-			if(stack != null && stack.getItem() instanceof ItemFood && !item.isDead && item.age >= slowdown) {
-				if(cooldown == 0) {
-					if(!remote) {
-						int val = ((ItemFood) stack.getItem()).func_150905_g(stack);
-						storedMana = val * val * 64;
-						cooldown = val * 10;
-						supertile.getWorldObj().playSoundEffect(supertile.xCoord, supertile.yCoord, supertile.zCoord, "random.eat", 0.2F, 0.5F + (float) Math.random() * 0.5F);
-						sync();
-					} else 
-						for(int i = 0; i < 10; i++) {
-							float m = 0.2F;
-							float mx = (float) (Math.random() - 0.5) * m;
-							float my = (float) (Math.random() - 0.5) * m;
-							float mz = (float) (Math.random() - 0.5) * m;
-							supertile.getWorldObj().spawnParticle("iconcrack_" + Item.getIdFromItem(stack.getItem()), item.posX, item.posY, item.posZ, mx, my, mz);
-						}
-							
-				}
+			if (stack == null || item.isDead || item.age < slowdown) continue;
 
-				if(!remote)
-					item.setDead();
+			int hungerValue = getFoodHungerValue(stack);
+			if (hungerValue <= 0) continue;
+
+			if (cooldown == 0) {
+				if (!remote) {
+					storedMana = hungerValue * hungerValue * 64;
+					cooldown = hungerValue * 10;
+					supertile.getWorldObj().playSoundEffect(supertile.xCoord, supertile.yCoord, supertile.zCoord, "random.eat", 0.2F, 0.5F + (float) Math.random() * 0.5F);
+					sync();
+				} else {
+					for (int i = 0; i < 10; i++) {
+						float m = 0.2F;
+						float mx = (float) (Math.random() - 0.5) * m;
+						float my = (float) (Math.random() - 0.5) * m;
+						float mz = (float) (Math.random() - 0.5) * m;
+						supertile.getWorldObj().spawnParticle("iconcrack_" + Item.getIdFromItem(stack.getItem()), item.posX, item.posY, item.posZ, mx, my, mz);
+					}
+				}
 			}
+			if (!remote) item.setDead();
 		}
 	}
 
@@ -78,13 +97,14 @@ public class SubTileGourmaryllis extends SubTileGenerating {
 	public void writeToPacketNBT(NBTTagCompound cmp) {
 		super.writeToPacketNBT(cmp);
 		cmp.setInteger(TAG_COOLDOWN, cooldown);
-		cmp.setInteger(TAG_COOLDOWN, cooldown);
+		cmp.setInteger(TAG_STORED_MANA, storedMana);
 	}
 
 	@Override
 	public void readFromPacketNBT(NBTTagCompound cmp) {
 		super.readFromPacketNBT(cmp);
 		cooldown = cmp.getInteger(TAG_COOLDOWN);
+		storedMana = cmp.getInteger(TAG_STORED_MANA);
 	}
 
 	@Override


### PR DESCRIPTION
as title says, lets Gourmaryllis consume GT Food, which is not of type ItemFood.
Unsure if this is the correct way to implement soft dep on gt5, but tested in full gtnh and it works like a charm.

Also fixed a small bug(i believe?) which i stumbled across, where TAG_COOLDOWN was stored twice instead of TAG_COOLDOWN and TAG_STORED_MANA.
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23780