### PR TITLE
fix spark mana transfer check

### DIFF
--- a/src/main/java/vazkii/botania/common/entity/EntitySpark.java
+++ b/src/main/java/vazkii/botania/common/entity/EntitySpark.java
@@ -171,10 +171,11 @@ public class EntitySpark extends Entity implements ISparkEntity {
 
 		if(!transfers.isEmpty()) {
 			int manaTotal = Math.min(TRANSFER_RATE * transfers.size(), tile.getCurrentMana());
-			int manaForEach = manaTotal / transfers.size();
-			int manaSpent = 0;
-
-			if(manaForEach > transfers.size()) {
+            if (manaTotal > 0){
+    			int manaForEach = manaTotal / transfers.size();
+                if (manaForEach == 0) manaForEach = 1;
+    			int manaSpent = 0;
+                
 				for(ISparkEntity spark : transfers) {
 					if(spark.getAttachedTile() == null || spark.getAttachedTile().isFull() || spark.areIncomingTransfersDone()) {
 						manaTotal -= manaForEach;
@@ -189,7 +190,7 @@ public class EntitySpark extends Entity implements ISparkEntity {
 					particlesTowards((Entity) spark);
 				}
 				tile.recieveMana(-manaSpent);
-			}
+            }
 		}
 
 		if(removeTransferants > 0)


### PR DESCRIPTION
EntitySpark update function has a check that only allows outgoing transfers if the total mana available for transfer is greater than the square of the number of transfers.
This feels arbitrary to the point it makes me think it's some sort of a typo. Also it makes it difficult to completely empty an object of mana.
The new logic only checks if there is any available mana to allow transfer. If the amount of mana available is less than the number of transfers, some targets get 1 point until the source runs out, the rest get nothing.