### PR TITLE
Clean up NEI handlers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ developmentEnvironmentUserName = Developer
 # - jabel: Jabel syntax-only support, compiles to J8 bytecode
 # - jvmDowngrader: Full modern Java via JVM Downgrader (syntax + stdlib APIs)
 # - modern: Native modern Java bytecode, no downgrading
-enableModernJavaSyntax = jabel
+enableModernJavaSyntax = jvmDowngrader
 
 # If set, ignores the above setting and compiles with the given toolchain. This may cause unexpected issues,
 # and should *not* be used in most situations. -1 disables this.

--- a/gradle.properties
+++ b/gradle.properties
@@ -65,7 +65,7 @@ enableModernJavaSyntax = jvmDowngrader
 # - external: Another dependency provides stubs (no constraint, no warning)
 # - (empty): Warning reminding you to configure stubs
 # Note: 'shade' option requires you to verify license compliance, see: https://github.com/unimined/JvmDowngrader/blob/main/LICENSE.md
-# jvmDowngraderStubsProvider =
+jvmDowngraderStubsProvider = gtnhlib
 
 # Enables injecting missing generics into the decompiled source code for a better coding experience.
 # Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.

--- a/src/main/java/vazkii/botania/client/integration/nei/IMCForNEI.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/IMCForNEI.java
@@ -1,0 +1,22 @@
+package vazkii.botania.client.integration.nei;
+
+import cpw.mods.fml.common.event.FMLInterModComms;
+import net.minecraft.nbt.NBTTagCompound;
+import vazkii.botania.client.integration.nei.recipe.RecipeHandlerBrewery;
+
+public class IMCForNEI {
+    public static void IMCSender() {
+        String brewery = new RecipeHandlerBrewery().getOverlayIdentifier();
+        sendCatalyst(brewery, "Botania:vial", -1);
+        sendCatalyst(brewery, "Botania:vial:1", -1);
+        sendCatalyst(brewery, "Botania:incenseStick", -1);
+    }
+
+    private static void sendCatalyst(String handlerName, String stack, int priority) {
+        NBTTagCompound nbt = new NBTTagCompound();
+        nbt.setString("handlerID", handlerName);
+        nbt.setString("itemName", stack);
+        nbt.setInteger("priority", priority);
+        FMLInterModComms.sendMessage("NotEnoughItems", "registerCatalystInfo", nbt);
+    }
+}

--- a/src/main/java/vazkii/botania/client/integration/nei/IMCForNEI.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/IMCForNEI.java
@@ -2,14 +2,12 @@ package vazkii.botania.client.integration.nei;
 
 import cpw.mods.fml.common.event.FMLInterModComms;
 import net.minecraft.nbt.NBTTagCompound;
-import vazkii.botania.client.integration.nei.recipe.RecipeHandlerBrewery;
 
 public class IMCForNEI {
     public static void IMCSender() {
-        String brewery = new RecipeHandlerBrewery().getOverlayIdentifier();
-        sendCatalyst(brewery, "Botania:vial", -1);
-        sendCatalyst(brewery, "Botania:vial:1", -1);
-        sendCatalyst(brewery, "Botania:incenseStick", -1);
+        sendCatalyst("botania.brewery", "Botania:vial", -1);
+        sendCatalyst("botania.brewery", "Botania:vial:1", -1);
+        sendCatalyst("botania.brewery", "Botania:incenseStick", -1);
     }
 
     private static void sendCatalyst(String handlerName, String stack, int priority) {

--- a/src/main/java/vazkii/botania/client/integration/nei/IMCForNEI.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/IMCForNEI.java
@@ -2,12 +2,14 @@ package vazkii.botania.client.integration.nei;
 
 import cpw.mods.fml.common.event.FMLInterModComms;
 import net.minecraft.nbt.NBTTagCompound;
+import vazkii.botania.client.integration.nei.recipe.RecipeHandlerBrewery;
 
 public class IMCForNEI {
     public static void IMCSender() {
-        sendCatalyst("botania.brewery", "Botania:vial", -1);
-        sendCatalyst("botania.brewery", "Botania:vial:1", -1);
-        sendCatalyst("botania.brewery", "Botania:incenseStick", -1);
+        sendCatalyst(RecipeHandlerBrewery.OVERLAY, "Botania:vial", -1);
+        sendCatalyst(RecipeHandlerBrewery.OVERLAY, "Botania:vial:1", -1);
+        sendCatalyst(RecipeHandlerBrewery.OVERLAY, "Botania:incenseStick", -1);
+        sendCatalyst(RecipeHandlerBrewery.OVERLAY, "Botania:bloodPendant", -1);
     }
 
     private static void sendCatalyst(String handlerName, String stack, int priority) {

--- a/src/main/java/vazkii/botania/client/integration/nei/NEIHelper.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/NEIHelper.java
@@ -4,10 +4,15 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.item.ItemStack;
 
 public class NEIHelper {
     public static final RenderItem renderItem = new RenderItem();
     public static final Minecraft mc = Minecraft.getMinecraft();
     public static final TextureManager textureManager = mc.getTextureManager();
     public static final FontRenderer font = mc.fontRenderer;
+
+    public static void renderItemIntoGUI(ItemStack flowerStack, int x, int y) {
+        renderItem.renderItemIntoGUI(font, textureManager, flowerStack, x, y);
+    }
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/NEIHelper.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/NEIHelper.java
@@ -1,0 +1,13 @@
+package vazkii.botania.client.integration.nei;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.entity.RenderItem;
+import net.minecraft.client.renderer.texture.TextureManager;
+
+public class NEIHelper {
+    public static final RenderItem renderItem = new RenderItem();
+    public static final Minecraft mc = Minecraft.getMinecraft();
+    public static final TextureManager textureManager = mc.getTextureManager();
+    public static final FontRenderer font = mc.fontRenderer;
+}

--- a/src/main/java/vazkii/botania/client/integration/nei/NEIHelper.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/NEIHelper.java
@@ -12,7 +12,7 @@ public class NEIHelper {
     public static final TextureManager textureManager = mc.getTextureManager();
     public static final FontRenderer font = mc.fontRenderer;
 
-    public static void renderItemIntoGUI(ItemStack flowerStack, int x, int y) {
-        renderItem.renderItemIntoGUI(font, textureManager, flowerStack, x, y);
+    public static void renderItemIntoGUI(ItemStack stack, int x, int y) {
+        renderItem.renderItemIntoGUI(font, textureManager, stack, x, y);
     }
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
@@ -23,118 +23,127 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class RecipeHandlerBrewery extends TemplateRecipeHandler {
 
-	public class CachedBreweryRecipe extends CachedRecipe {
+    public class CachedBreweryRecipe extends CachedRecipe {
 
-		public List<PositionedStack> inputs = new ArrayList<>();
-		public PositionedStack output;
-		public int mana;
+        public List<PositionedStack> inputs = new ArrayList<>();
+        public PositionedStack output;
+        public int mana;
 
-		public CachedBreweryRecipe(RecipeBrew recipe, ItemStack vial) {
-			if(recipe == null)
-				return;
+        public CachedBreweryRecipe(RecipeBrew recipe, ItemStack vial) {
+            if (recipe == null) return;
 
-			setIngredients(recipe.getInputs());
-			ItemStack toVial;
-			if (vial == null)
-				toVial = new ItemStack(ModItems.vial);
-			else
-				toVial = vial.copy();
-			toVial.stackSize = 1;
-			inputs.add(new PositionedStack(toVial, 39, 42));
+            setIngredients(recipe.getInputs());
+            ItemStack toVial;
+            if (vial == null) {
+                toVial = new ItemStack(ModItems.vial);
+            } else {
+                toVial = vial.copy();
+            }
+            toVial.stackSize = 1;
+            inputs.add(new PositionedStack(toVial, 39, 42));
 
-			output = new PositionedStack(recipe.getOutput(toVial), 87, 42);
-		}
+            output = new PositionedStack(recipe.getOutput(toVial), 87, 42);
+        }
 
-		public CachedBreweryRecipe(RecipeBrew recipe) {
-			this(recipe, null);
-		}
+        public CachedBreweryRecipe(RecipeBrew recipe) {
+            this(recipe, null);
+        }
 
-		public void setIngredients(List<Object> inputs) {
-			int left = 96 - inputs.size() * 18 / 2;
+        public void setIngredients(List<Object> inputs) {
+            int left = 96 - inputs.size() * 18 / 2;
 
-			int i = 0;
-			for (Object o : inputs) {
-				if (o instanceof String)
-					this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), left + i * 18, 6));
-				else
-					this.inputs.add(new PositionedStack(o, left + i * 18, 6));
+            int i = 0;
+            for (Object o : inputs) {
+                if (o instanceof String) {
+                    this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), left + i * 18, 6));
+                } else {
+                    this.inputs.add(new PositionedStack(o, left + i * 18, 6));
+                }
+                i++;
+            }
+        }
 
-				i++;
-			}
-		}
+        @Override
+        public List<PositionedStack> getIngredients() {
+            return inputs;
+        }
 
-		@Override
-		public List<PositionedStack> getIngredients() {
-			return inputs;
-		}
+        @Override
+        public PositionedStack getResult() {
+            return output;
+        }
 
-		@Override
-		public PositionedStack getResult() {
-			return output;
-		}
+    }
 
-	}
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.brewery");
+    }
 
-	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.brewery");
-	}
+    @Override
+    public String getOverlayIdentifier() {
+        return "botania.brewery";
+    }
 
-	@Override
-	public String getGuiTexture() {
-		return LibResources.GUI_NEI_BREWERY;
-	}
+    @Override
+    public String getGuiTexture() {
+        return LibResources.GUI_NEI_BREWERY;
+    }
 
-	@Override
-	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(87, 25, 15, 14), "botania.brewery"));
-	}
+    @Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(87, 25, 15, 14), getOverlayIdentifier()));
+    }
 
-	@Override
-	public void drawBackground(int recipe) {
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-		GuiDraw.changeTexture(getGuiTexture());
-		GuiDraw.drawTexturedModalRect(0, 0, 0, 0, 166, 65);
-	}
+    @Override
+    public void drawBackground(int recipe) {
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        GuiDraw.changeTexture(getGuiTexture());
+        GuiDraw.drawTexturedModalRect(0, 0, 0, 0, 166, 65);
+    }
 
-	@Override
-	public void loadCraftingRecipes(String outputId, Object... results) {
-		if(outputId.equals("botania.brewery"))
-			for(RecipeBrew recipe : BotaniaAPI.brewRecipes)
-				arecipes.add(new CachedBreweryRecipe(recipe));
-		else super.loadCraftingRecipes(outputId, results);
-	}
+    @Override
+    public void loadCraftingRecipes(String outputId, Object... results) {
+        if (outputId.equals(getOverlayIdentifier())) {
+            for (RecipeBrew recipe : BotaniaAPI.brewRecipes) {
+                arecipes.add(new CachedBreweryRecipe(recipe));
+            }
+        } else {
+            super.loadCraftingRecipes(outputId, results);
+        }
+    }
 
-	@Override
-	public void loadCraftingRecipes(ItemStack result) {
-		if(result.getItem() instanceof IBrewItem)
-			for(RecipeBrew recipe : BotaniaAPI.brewRecipes) {
-				if(recipe == null)
-					continue;
+    @Override
+    public void loadCraftingRecipes(ItemStack result) {
+        if (!(result.getItem() instanceof IBrewItem)) {
+            return;
+        }
+        for (RecipeBrew recipe : BotaniaAPI.brewRecipes) {
+            if (recipe != null && ((IBrewItem) result.getItem()).getBrew(result) == recipe.getBrew()) {
+                arecipes.add(new CachedBreweryRecipe(recipe));
+            }
+        }
+    }
 
-				if(((IBrewItem) result.getItem()).getBrew(result) == recipe.getBrew())
-					arecipes.add(new CachedBreweryRecipe(recipe));
-			}
-	}
+    @Override
+    public void loadUsageRecipes(ItemStack ingredient) {
+        if (ingredient.getItem() instanceof IBrewContainer) {
+            for (RecipeBrew recipe : BotaniaAPI.brewRecipes) {
+                if (recipe != null && recipe.getOutput(ingredient) != null) {
+                    arecipes.add(new CachedBreweryRecipe(recipe, ingredient));
+                }
+            }
+        } else {
+            for (RecipeBrew recipe : BotaniaAPI.brewRecipes) {
+                if (recipe == null)
+                    continue;
 
-	@Override
-	public void loadUsageRecipes(ItemStack ingredient) {
-		if(ingredient.getItem() instanceof IBrewContainer) {
-			for(RecipeBrew recipe : BotaniaAPI.brewRecipes) {
-				if(recipe == null)
-					continue;
-
-				if(recipe.getOutput(ingredient) != null)
-					arecipes.add(new CachedBreweryRecipe(recipe, ingredient));
-			}
-		} else for(RecipeBrew recipe : BotaniaAPI.brewRecipes) {
-			if(recipe == null)
-				continue;
-
-			CachedBreweryRecipe crecipe = new CachedBreweryRecipe(recipe);
-			if(ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.inputs, ingredient))
-				arecipes.add(crecipe);
-		}
-	}
+                CachedBreweryRecipe crecipe = new CachedBreweryRecipe(recipe);
+                if (ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.inputs, ingredient)) {
+                    arecipes.add(crecipe);
+                }
+            }
+        }
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
@@ -65,7 +65,7 @@ public class RecipeHandlerBrewery extends TemplateRecipeHandler {
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, inputs);
+			return inputs;
 		}
 
 		@Override

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
@@ -23,6 +23,8 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class RecipeHandlerBrewery extends TemplateRecipeHandler {
 
+    public static final String OVERLAY = "botania.brewery";
+
     public class CachedBreweryRecipe extends CachedRecipe {
 
         public List<PositionedStack> inputs = new ArrayList<>();
@@ -38,8 +40,8 @@ public class RecipeHandlerBrewery extends TemplateRecipeHandler {
                 toVial = new ItemStack(ModItems.vial);
             } else {
                 toVial = vial.copy();
+                toVial.stackSize = 1;
             }
-            toVial.stackSize = 1;
             inputs.add(new PositionedStack(toVial, 39, 42));
 
             output = new PositionedStack(recipe.getOutput(toVial), 87, 42);
@@ -52,14 +54,13 @@ public class RecipeHandlerBrewery extends TemplateRecipeHandler {
         public void setIngredients(List<Object> inputs) {
             int left = 96 - inputs.size() * 18 / 2;
 
-            int i = 0;
-            for (Object o : inputs) {
-                if (o instanceof String) {
-                    this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), left + i * 18, 6));
+            for (int i = 0; i < inputs.size(); i++) {
+                Object o = inputs.get(i);
+                if (o instanceof String oredict) {
+                    this.inputs.add(new PositionedStack(OreDictionary.getOres(oredict), left + i * 18, 6));
                 } else {
                     this.inputs.add(new PositionedStack(o, left + i * 18, 6));
                 }
-                i++;
             }
         }
 
@@ -82,7 +83,7 @@ public class RecipeHandlerBrewery extends TemplateRecipeHandler {
 
     @Override
     public String getOverlayIdentifier() {
-        return "botania.brewery";
+        return OVERLAY;
     }
 
     @Override
@@ -115,11 +116,9 @@ public class RecipeHandlerBrewery extends TemplateRecipeHandler {
 
     @Override
     public void loadCraftingRecipes(ItemStack result) {
-        if (!(result.getItem() instanceof IBrewItem)) {
-            return;
-        }
+        if (!(result.getItem() instanceof IBrewItem brew)) return;
         for (RecipeBrew recipe : BotaniaAPI.brewRecipes) {
-            if (recipe != null && ((IBrewItem) result.getItem()).getBrew(result) == recipe.getBrew()) {
+            if (recipe != null && brew.getBrew(result) == recipe.getBrew()) {
                 arecipes.add(new CachedBreweryRecipe(recipe));
             }
         }
@@ -135,9 +134,7 @@ public class RecipeHandlerBrewery extends TemplateRecipeHandler {
             }
         } else {
             for (RecipeBrew recipe : BotaniaAPI.brewRecipes) {
-                if (recipe == null)
-                    continue;
-
+                if (recipe == null) continue;
                 CachedBreweryRecipe crecipe = new CachedBreweryRecipe(recipe);
                 if (ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.inputs, ingredient)) {
                     arecipes.add(crecipe);

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
@@ -57,10 +57,9 @@ public class RecipeHandlerBrewery extends TemplateRecipeHandler {
             for (int i = 0; i < inputs.size(); i++) {
                 Object o = inputs.get(i);
                 if (o instanceof String oreName) {
-                    this.inputs.add(new PositionedStack(OreDictionary.getOres(oreName), left + i * 18, 6));
-                } else {
-                    this.inputs.add(new PositionedStack(o, left + i * 18, 6));
+                    o = OreDictionary.getOres(oreName);
                 }
+                this.inputs.add(new PositionedStack(o, left + i * 18, 6));
             }
         }
 

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerBrewery.java
@@ -56,8 +56,8 @@ public class RecipeHandlerBrewery extends TemplateRecipeHandler {
 
             for (int i = 0; i < inputs.size(); i++) {
                 Object o = inputs.get(i);
-                if (o instanceof String oredict) {
-                    this.inputs.add(new PositionedStack(OreDictionary.getOres(oredict), left + i * 18, 6));
+                if (o instanceof String oreName) {
+                    this.inputs.add(new PositionedStack(OreDictionary.getOres(oreName), left + i * 18, 6));
                 } else {
                     this.inputs.add(new PositionedStack(o, left + i * 18, 6));
                 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
@@ -52,7 +52,7 @@ public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, inputs);
+			return inputs;
 		}
 
 		@Override

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
@@ -78,11 +78,6 @@ public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
 	}
 
 	@Override
-	public int recipiesPerPage() {
-		return 1;
-	}
-
-	@Override
 	public void drawBackground(int recipe) {
 		super.drawBackground(recipe);
 		GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
@@ -4,7 +4,6 @@ import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -26,119 +25,129 @@ import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
 
-	public class CachedElvenTradeRecipe extends CachedRecipe {
+    public class CachedElvenTradeRecipe extends CachedRecipe {
 
-		public List<PositionedStack> inputs = new ArrayList<>();
-		public PositionedStack output;
+        public List<PositionedStack> inputs = new ArrayList<>();
+        public PositionedStack output;
 
-		public CachedElvenTradeRecipe(RecipeElvenTrade recipe) {
-			if(recipe == null)
-				return;
+        public CachedElvenTradeRecipe(RecipeElvenTrade recipe) {
+            if (recipe == null)
+                return;
 
-			setIngredients(recipe.getInputs());
-			output = new PositionedStack(recipe.getOutput(), 107, 46);
-		}
+            setIngredients(recipe.getInputs());
+            output = new PositionedStack(recipe.getOutput(), 107, 46);
+        }
 
-		public void setIngredients(List<Object> inputs) {
-			int i = 0;
-			for(Object o : inputs) {
-				if(o instanceof String)
-					this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), 60 + i * 18, 6));
-				else this.inputs.add(new PositionedStack(o, 60 + i * 18, 6));
+        public void setIngredients(List<Object> inputs) {
+            int i = 0;
+            for (Object o : inputs) {
+                if (o instanceof String) {
+                    this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), 60 + i * 18, 6));
+                } else {
+                    this.inputs.add(new PositionedStack(o, 60 + i * 18, 6));
+                }
 
-				i++;
-			}
-		}
+                i++;
+            }
+        }
 
-		@Override
-		public List<PositionedStack> getIngredients() {
-			return inputs;
-		}
+        @Override
+        public List<PositionedStack> getIngredients() {
+            return inputs;
+        }
 
-		@Override
-		public PositionedStack getResult() {
-			return output;
-		}
+        @Override
+        public PositionedStack getResult() {
+            return output;
+        }
 
-	}
+    }
 
-	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.elvenTrade");
-	}
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.elvenTrade");
+    }
 
-	@Override
-	public String getGuiTexture() {
-		return LibResources.GUI_NEI_BLANK;
-	}
+    @Override
+    public String getOverlayIdentifier() {
+        return "botania.elvenTrade";
+    }
 
-	@Override
-	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(35, 30, 48, 48), "botania.elvenTrade"));
-	}
+    @Override
+    public String getGuiTexture() {
+        return LibResources.GUI_NEI_BLANK;
+    }
 
-	@Override
-	public void drawBackground(int recipe) {
-		super.drawBackground(recipe);
-		GL11.glEnable(GL11.GL_BLEND);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.7F);
-		GuiDraw.changeTexture(LibResources.GUI_ELVEN_TRADE_OVERLAY);
-		GuiDraw.drawTexturedModalRect(30, 10, 17, 17, 100, 80);
-		GL11.glDisable(GL11.GL_BLEND);
-		GuiDraw.changeTexture(TextureMap.locationBlocksTexture);
-		RenderItem.getInstance().renderIcon(35, 29, BlockAlfPortal.portalTex, 48, 48);
-	}
+    @Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(35, 30, 48, 48), getOverlayIdentifier()));
+    }
 
-	@Override
-	public void loadCraftingRecipes(String outputId, Object... results) {
-		if (outputId.equals("botania.elvenTrade")) {
+    @Override
+    public void drawBackground(int recipe) {
+        super.drawBackground(recipe);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.7F);
+        GuiDraw.changeTexture(LibResources.GUI_ELVEN_TRADE_OVERLAY);
+        GuiDraw.drawTexturedModalRect(30, 10, 17, 17, 100, 80);
+        GL11.glDisable(GL11.GL_BLEND);
+        GuiDraw.changeTexture(TextureMap.locationBlocksTexture);
+        RenderItem.getInstance().renderIcon(35, 29, BlockAlfPortal.portalTex, 48, 48);
+    }
+
+    @Override
+    public void loadCraftingRecipes(String outputId, Object... results) {
+        if (outputId.equals(getOverlayIdentifier())) {
             for (RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
                 arecipes.add(new CachedElvenTradeRecipe(recipe));
             }
         } else {
-			super.loadCraftingRecipes(outputId, results);
-		}
-	}
-
-	@Override
-	public void loadCraftingRecipes(ItemStack result) {
-        for (RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
-            if (NEIServerUtils.areStacksSameTypeCrafting(recipe.getOutput(), result))
-                arecipes.add(new CachedElvenTradeRecipe(recipe));
+            super.loadCraftingRecipes(outputId, results);
         }
     }
 
-	@Override
-	public void loadUsageRecipes(ItemStack ingredient) {
+    @Override
+    public void loadCraftingRecipes(ItemStack result) {
+        for (RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
+            if (NEIServerUtils.areStacksSameTypeCrafting(recipe.getOutput(), result)) {
+                arecipes.add(new CachedElvenTradeRecipe(recipe));
+            }
+        }
+    }
+
+    @Override
+    public void loadUsageRecipes(ItemStack ingredient) {
         for (RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
             CachedElvenTradeRecipe crecipe = new CachedElvenTradeRecipe(recipe);
-            if (crecipe.contains(crecipe.inputs, ingredient))
+            if (crecipe.contains(crecipe.inputs, ingredient)) {
                 arecipes.add(crecipe);
+            }
         }
     }
 
-	// hide dummy recipes
-	private List<RecipeElvenTrade> filteredElvenTradeRecipes() {
-		return BotaniaAPI.elvenTradeRecipes
-			.stream()
-			.filter(recipe -> {
-				if (recipe == null) {
-					return false;
-				}
-				if (recipe.getInputs().size() == 1) {
-					return !stackSame(recipe.getOutput(), recipe.getInputs().get(0));
-				}
-				return true;
-			})
-			.collect(Collectors.toList());
-	}
+    private List<RecipeElvenTrade> filteredElvenTradeRecipes() {
+        List<RecipeElvenTrade> result = new ArrayList<>();
 
-	private boolean stackSame(ItemStack stack, Object obj) {
-		if (obj instanceof String) {
-			return OreDictionary.getOres((String) obj).stream().anyMatch(s -> ItemNBTHelper.areStacksSameTypeCraftingWithNBT(stack, s));
-		} else {
-			return Arrays.stream(NEIServerUtils.extractRecipeItems(obj)).anyMatch(s -> ItemNBTHelper.areStacksSameTypeCraftingWithNBT(stack, s));
-		}
-	}
+        for (RecipeElvenTrade recipe : BotaniaAPI.elvenTradeRecipes) {
+            if (recipe == null) {
+                continue;
+            }
+
+            // Don't show dummy recipes where input and output are the same
+            if (recipe.getInputs().size() != 1 || !stackSame(recipe.getOutput(), recipe.getInputs().get(0))) {
+                result.add(recipe);
+            }
+        }
+
+        return result;
+    }
+
+    private boolean stackSame(ItemStack stack, Object obj) {
+        if (obj instanceof String) {
+            return OreDictionary.getOres((String) obj).stream().anyMatch(s -> ItemNBTHelper.areStacksSameTypeCraftingWithNBT(stack, s));
+        } else {
+            return Arrays.stream(NEIServerUtils.extractRecipeItems(obj)).anyMatch(s -> ItemNBTHelper.areStacksSameTypeCraftingWithNBT(stack, s));
+        }
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
@@ -94,53 +94,33 @@ public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
 		RenderItem.getInstance().renderIcon(35, 29, BlockAlfPortal.portalTex, 48, 48);
 	}
 
-	private static boolean hasElvenKnowledge() {
-		/*EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-		if (player != null) {
-			for (ItemStack stack : player.inventory.mainInventory) {
-				if (stack != null && stack.getItem() instanceof ILexicon) {
-					ILexicon lexicon = (ILexicon) stack.getItem();
-					if (lexicon.isKnowledgeUnlocked(stack, BotaniaAPI.elvenKnowledge)) {
-						return true;
-					}
-				}
-			}
-		}
-		return false;*/
-		return true;
-	}
-
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		if(outputId.equals("botania.elvenTrade") && hasElvenKnowledge()) {
-			if(hasElvenKnowledge()) {
-				for(RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
-					arecipes.add(new CachedElvenTradeRecipe(recipe));
-				}
-			}
-		} else super.loadCraftingRecipes(outputId, results);
+		if (outputId.equals("botania.elvenTrade")) {
+            for (RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
+                arecipes.add(new CachedElvenTradeRecipe(recipe));
+            }
+        } else {
+			super.loadCraftingRecipes(outputId, results);
+		}
 	}
 
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
-		if(hasElvenKnowledge()) {
-			for(RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
-				if(NEIServerUtils.areStacksSameTypeCrafting(recipe.getOutput(), result))
-					arecipes.add(new CachedElvenTradeRecipe(recipe));
-			}
-		}
-	}
+        for (RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
+            if (NEIServerUtils.areStacksSameTypeCrafting(recipe.getOutput(), result))
+                arecipes.add(new CachedElvenTradeRecipe(recipe));
+        }
+    }
 
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
-		if(hasElvenKnowledge()) {
-			for(RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
-				CachedElvenTradeRecipe crecipe = new CachedElvenTradeRecipe(recipe);
-				if(crecipe.contains(crecipe.inputs, ingredient))
-					arecipes.add(crecipe);
-			}
-		}
-	}
+        for (RecipeElvenTrade recipe : filteredElvenTradeRecipes()) {
+            CachedElvenTradeRecipe crecipe = new CachedElvenTradeRecipe(recipe);
+            if (crecipe.contains(crecipe.inputs, ingredient))
+                arecipes.add(crecipe);
+        }
+    }
 
 	// hide dummy recipes
 	private List<RecipeElvenTrade> filteredElvenTradeRecipes() {

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.item.ItemStack;
@@ -123,15 +122,12 @@ public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
         }
     }
 
-    private List<RecipeElvenTrade> filteredElvenTradeRecipes() {
-        return Lists.newArrayList(
-                Iterables.filter(
-                        BotaniaAPI.elvenTradeRecipes,
-                        recipe -> recipe != null
-                                && (recipe.getInputs().size() != 1
-                                || !stackSame(recipe.getOutput(), recipe.getInputs().getFirst()))
-                )
-        );
+    private Iterable<RecipeElvenTrade> filteredElvenTradeRecipes() {
+        return Iterables.filter(
+                BotaniaAPI.elvenTradeRecipes,
+                recipe -> recipe != null
+                        && (recipe.getInputs().size() != 1
+                        || !stackSame(recipe.getOutput(), recipe.getInputs().getFirst())));
     }
 
     private boolean stackSame(ItemStack stack, Object obj) {

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.item.ItemStack;
@@ -25,29 +27,27 @@ import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
 
+    public static final String OVERLAY = "botania.elvenTrade";
+
     public class CachedElvenTradeRecipe extends CachedRecipe {
 
         public List<PositionedStack> inputs = new ArrayList<>();
         public PositionedStack output;
 
         public CachedElvenTradeRecipe(RecipeElvenTrade recipe) {
-            if (recipe == null)
-                return;
-
+            if (recipe == null) return;
             setIngredients(recipe.getInputs());
             output = new PositionedStack(recipe.getOutput(), 107, 46);
         }
 
         public void setIngredients(List<Object> inputs) {
-            int i = 0;
-            for (Object o : inputs) {
-                if (o instanceof String) {
-                    this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), 60 + i * 18, 6));
+            for (int i = 0; i < inputs.size(); i++) {
+                Object o = inputs.get(i);
+                if (o instanceof String oreName) {
+                    this.inputs.add(new PositionedStack(OreDictionary.getOres(oreName), 60 + i * 18, 6));
                 } else {
                     this.inputs.add(new PositionedStack(o, 60 + i * 18, 6));
                 }
-
-                i++;
             }
         }
 
@@ -60,7 +60,6 @@ public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
         public PositionedStack getResult() {
             return output;
         }
-
     }
 
     @Override
@@ -70,7 +69,7 @@ public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
 
     @Override
     public String getOverlayIdentifier() {
-        return "botania.elvenTrade";
+        return OVERLAY;
     }
 
     @Override
@@ -126,27 +125,27 @@ public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
     }
 
     private List<RecipeElvenTrade> filteredElvenTradeRecipes() {
-        List<RecipeElvenTrade> result = new ArrayList<>();
-
-        for (RecipeElvenTrade recipe : BotaniaAPI.elvenTradeRecipes) {
-            if (recipe == null) {
-                continue;
-            }
-
-            // Don't show dummy recipes where input and output are the same
-            if (recipe.getInputs().size() != 1 || !stackSame(recipe.getOutput(), recipe.getInputs().get(0))) {
-                result.add(recipe);
-            }
-        }
-
-        return result;
+        return Lists.newArrayList(
+                Iterables.filter(
+                        BotaniaAPI.elvenTradeRecipes,
+                        recipe -> recipe != null
+                                && (recipe.getInputs().size() != 1
+                                || !stackSame(recipe.getOutput(), recipe.getInputs().getFirst()))
+                )
+        );
     }
 
     private boolean stackSame(ItemStack stack, Object obj) {
-        if (obj instanceof String) {
-            return OreDictionary.getOres((String) obj).stream().anyMatch(s -> ItemNBTHelper.areStacksSameTypeCraftingWithNBT(stack, s));
+        if (obj instanceof String oreName) {
+            return Iterables.any(
+                    OreDictionary.getOres(oreName),
+                    s -> ItemNBTHelper.areStacksSameTypeCraftingWithNBT(stack, s)
+            );
         } else {
-            return Arrays.stream(NEIServerUtils.extractRecipeItems(obj)).anyMatch(s -> ItemNBTHelper.areStacksSameTypeCraftingWithNBT(stack, s));
+            return Iterables.any(
+                    Arrays.asList(NEIServerUtils.extractRecipeItems(obj)),
+                    s -> ItemNBTHelper.areStacksSameTypeCraftingWithNBT(stack, s)
+            );
         }
     }
 

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerElvenTrade.java
@@ -44,10 +44,9 @@ public class RecipeHandlerElvenTrade extends TemplateRecipeHandler {
             for (int i = 0; i < inputs.size(); i++) {
                 Object o = inputs.get(i);
                 if (o instanceof String oreName) {
-                    this.inputs.add(new PositionedStack(OreDictionary.getOres(oreName), 60 + i * 18, 6));
-                } else {
-                    this.inputs.add(new PositionedStack(o, 60 + i * 18, 6));
+                    o = OreDictionary.getOres(oreName);
                 }
+                this.inputs.add(new PositionedStack(o, 60 + i * 18, 6));
             }
         }
 

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerFloatingFlowers.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerFloatingFlowers.java
@@ -31,7 +31,7 @@ public class RecipeHandlerFloatingFlowers extends TemplateRecipeHandler {
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, inputs);
+			return inputs;
 		}
 
 		@Override

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerFloatingFlowers.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerFloatingFlowers.java
@@ -17,65 +17,70 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class RecipeHandlerFloatingFlowers extends TemplateRecipeHandler {
 
-	public class CachedFloatingFlowerRecipe extends CachedRecipe {
+    public class CachedFloatingFlowerRecipe extends CachedRecipe {
 
-		public List<PositionedStack> inputs = new ArrayList<>();
-		public PositionedStack output;
+        public List<PositionedStack> inputs = new ArrayList<>();
+        public PositionedStack output;
 
-		public CachedFloatingFlowerRecipe(ItemStack floatingFlower, ItemStack specialFlower, ItemStack output) {
-			inputs.add(new PositionedStack(floatingFlower, 25, 6));
-			inputs.add(new PositionedStack(specialFlower, 43, 6));
-			this.output = new PositionedStack(output, 119, 24);
-			this.output.setMaxSize(1);
-		}
+        public CachedFloatingFlowerRecipe(ItemStack floatingFlower, ItemStack specialFlower, ItemStack output) {
+            inputs.add(new PositionedStack(floatingFlower, 25, 6));
+            inputs.add(new PositionedStack(specialFlower, 43, 6));
+            this.output = new PositionedStack(output, 119, 24);
+            this.output.setMaxSize(1);
+        }
 
-		@Override
-		public List<PositionedStack> getIngredients() {
-			return inputs;
-		}
+        @Override
+        public List<PositionedStack> getIngredients() {
+            return inputs;
+        }
 
-		@Override
-		public PositionedStack getResult() {
-			return output;
-		}
+        @Override
+        public PositionedStack getResult() {
+            return output;
+        }
 
-	}
+    }
 
-	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.floatingFlowers");
-	}
-
-	@Override
-	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "crafting"));
-	}
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.floatingFlowers");
+    }
 
 	@Override
-	public String getGuiTexture() {
-		return "textures/gui/container/crafting_table.png";
+	public String getOverlayIdentifier() {
+		return "crafting2x2";
 	}
 
-	@Override
-	public void loadCraftingRecipes(ItemStack result) {
-		if(Block.getBlockFromItem(result.getItem()) instanceof BlockFloatingSpecialFlower) {
-			ItemStack floatingFlower = new ItemStack(ModBlocks.floatingFlower, 1, OreDictionary.WILDCARD_VALUE);
-			ItemStack specialFlower = new ItemStack(ModBlocks.specialFlower);
-			specialFlower.setTagCompound((NBTTagCompound) result.getTagCompound().copy());
+    @Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(84, 23, 24, 18), "crafting"));
+    }
 
-			arecipes.add(new CachedFloatingFlowerRecipe(floatingFlower, specialFlower, result.copy()));
-		}
-	}
+    @Override
+    public String getGuiTexture() {
+        return "textures/gui/container/crafting_table.png";
+    }
 
-	@Override
-	public void loadUsageRecipes(ItemStack ingredient) {
-		if(Block.getBlockFromItem(ingredient.getItem()) instanceof BlockSpecialFlower) {
-			ItemStack floatingFlower = new ItemStack(ModBlocks.floatingFlower, 1, OreDictionary.WILDCARD_VALUE);
-			ItemStack result = new ItemStack(ModBlocks.floatingSpecialFlower);
-			result.setTagCompound((NBTTagCompound) ingredient.getTagCompound().copy());
+    @Override
+    public void loadCraftingRecipes(ItemStack result) {
+        if (Block.getBlockFromItem(result.getItem()) instanceof BlockFloatingSpecialFlower) {
+            ItemStack floatingFlower = new ItemStack(ModBlocks.floatingFlower, 1, OreDictionary.WILDCARD_VALUE);
+            ItemStack specialFlower = new ItemStack(ModBlocks.specialFlower);
+            specialFlower.setTagCompound((NBTTagCompound) result.getTagCompound().copy());
 
-			arecipes.add(new CachedFloatingFlowerRecipe(floatingFlower, ingredient.copy(), result));
-		}
-	}
+            arecipes.add(new CachedFloatingFlowerRecipe(floatingFlower, specialFlower, result.copy()));
+        }
+    }
+
+    @Override
+    public void loadUsageRecipes(ItemStack ingredient) {
+        if (Block.getBlockFromItem(ingredient.getItem()) instanceof BlockSpecialFlower) {
+            ItemStack floatingFlower = new ItemStack(ModBlocks.floatingFlower, 1, OreDictionary.WILDCARD_VALUE);
+            ItemStack result = new ItemStack(ModBlocks.floatingSpecialFlower);
+            result.setTagCompound((NBTTagCompound) ingredient.getTagCompound().copy());
+
+            arecipes.add(new CachedFloatingFlowerRecipe(floatingFlower, ingredient.copy(), result));
+        }
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
@@ -83,7 +83,7 @@ public class RecipeHandlerLexicaBotania extends TemplateRecipeHandler {
 
         CachedLexicaBotaniaRecipe recipeObj = ((CachedLexicaBotaniaRecipe) arecipes.get(recipe));
 
-        NEIHelper.renderItem.renderItemIntoGUI(NEIHelper.font, NEIHelper.textureManager, lexicaStack, 51, 5);
+        NEIHelper.renderItemIntoGUI(lexicaStack, 51, 5);
 
         GuiDraw.drawStringC(
                 EnumChatFormatting.UNDERLINE + StatCollector.translateToLocal(recipeObj.entry.getUnlocalizedName()),

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
@@ -77,11 +77,6 @@ public class RecipeHandlerLexicaBotania extends TemplateRecipeHandler {
 	public String getGuiTexture() {
 		return LibResources.GUI_NEI_BLANK;
 	}
-
-	@Override
-	public int recipiesPerPage() {
-		return 1;
-	}
 	
 	@Override
 	public void loadTransferRects() {

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
@@ -2,22 +2,22 @@
  * This class was created by <Vazkii>. It's distributed as
  * part of the Botania Mod. Get the Source Code in github:
  * https://github.com/Vazkii/Botania
- * 
+ * <p>
  * Botania is Open Source and distributed under the
  * Botania License: http://botaniamod.net/license.php
- * 
+ * <p>
  * File Created @ [12/12/2015, 23:25:47 (GMT)]
  */
 package vazkii.botania.client.integration.nei.recipe;
 
 import java.awt.Rectangle;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -34,116 +34,126 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class RecipeHandlerLexicaBotania extends TemplateRecipeHandler {
 
-	public class CachedLexicaBotaniaRecipe extends CachedRecipe {
+    private static final RenderItem renderItem = new RenderItem();
+    private static final Minecraft mc = Minecraft.getMinecraft();
+    private static final ItemStack lexicaStack = new ItemStack(ModItems.lexicon);
 
-		public LexiconEntry entry;
-		public PositionedStack item;
-		public List<PositionedStack> otherStacks = new ArrayList<>();
+    public class CachedLexicaBotaniaRecipe extends CachedRecipe {
 
-		public CachedLexicaBotaniaRecipe(ItemStack stack, LexiconEntry entry) {
-			otherStacks.add(new PositionedStack(new ItemStack(ModItems.lexicon), 51, 5));
-			item = new PositionedStack(stack, 91, 5);
-			this.entry = entry;
-		}
+        public LexiconEntry entry;
+        public PositionedStack item;
 
-		@Override
-		public List<PositionedStack> getIngredients() {
-			return otherStacks;
-		}
+        public CachedLexicaBotaniaRecipe(ItemStack stack, LexiconEntry entry) {
+            item = new PositionedStack(stack, 91, 5);
+            this.entry = entry;
+        }
 
-		@Override
-		public PositionedStack getResult() {
-			return item;
-		}
+        @Override
+        public PositionedStack getResult() {
+            return item;
+        }
 
-		@Override
-		public List<PositionedStack> getOtherStacks() {
-			return otherStacks;
-		}
+        @Override
+        public boolean contains(Collection<PositionedStack> ingredients, ItemStack ingredient) {
+            return ingredient.getItem() == ModItems.lexicon;
+        }
 
-		@Override
-		public boolean contains(Collection<PositionedStack> ingredients, ItemStack ingredient) {
-			return ingredient.getItem() == ModItems.lexicon;
-		}
+    }
 
-	}
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.lexica");
+    }
 
-	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.lexica");
-	}
+    @Override
+    public String getOverlayIdentifier() {
+        return "botania.lexica";
+    }
 
-	@Override
-	public String getGuiTexture() {
-		return LibResources.GUI_NEI_BLANK;
-	}
-	
-	@Override
-	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(50, 4, 18, 18), "botania.lexica"));
-	}
-	
-	@Override
-	public void drawBackground(int recipe) {
-		super.drawBackground(recipe);
-		
-		FontRenderer font = Minecraft.getMinecraft().fontRenderer;
-		CachedLexicaBotaniaRecipe recipeObj = ((CachedLexicaBotaniaRecipe) arecipes.get(recipe));
+    @Override
+    public String getGuiTexture() {
+        return LibResources.GUI_NEI_BLANK;
+    }
 
-		String s = EnumChatFormatting.UNDERLINE + StatCollector.translateToLocal(recipeObj.entry.getUnlocalizedName());
-		font.drawString(s, 82 - font.getStringWidth(s) / 2, 30, 4210752);
-		
-		KnowledgeType type = recipeObj.entry.getKnowledgeType();
-		s = type.color + StatCollector.translateToLocal(type.getUnlocalizedName()).replaceAll("\\&.", "");
-		font.drawString(s, 82 - font.getStringWidth(s) / 2, 42, 4210752);
-		
-		s = "\"" + StatCollector.translateToLocal(recipeObj.entry.getTagline()) + "\"";
-		PageText.renderText(5, 42, 160, 200, s);
-		
-		String key = LexiconRecipeMappings.stackToString(recipeObj.item.item);
-		String quickInfo = "botania.nei.quickInfo:" + key;
-		String quickInfoLocal = StatCollector.translateToLocal(quickInfo);
-		
-		if(GuiScreen.isShiftKeyDown() && GuiScreen.isCtrlKeyDown() && Minecraft.getMinecraft().gameSettings.advancedItemTooltips)
-			s = "name: " + key;
-		else if(quickInfo.equals(quickInfoLocal))
-			s = StatCollector.translateToLocal("botania.nei.lexicaNoInfo");
-		else {
-			s = StatCollector.translateToLocal("botania.nei.lexicaSeparator");
-			font.drawString(s, 82 - font.getStringWidth(s) / 2, 80, 4210752);
-			s = quickInfoLocal;
-		}
-		
-		PageText.renderText(5, 80, 160, 200, s);
-	}
+    @Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(50, 4, 18, 18), getOverlayIdentifier()));
+    }
 
-	@Override
-	public void loadCraftingRecipes(String outputId, Object... results) {
-		if(outputId.equals("botania.lexica")) {
-			for(LexiconEntry entry : BotaniaAPI.getAllEntries()) {
-				List<ItemStack> stacks = entry.getDisplayedRecipes();
-				for(ItemStack stack : stacks)
-					arecipes.add(new CachedLexicaBotaniaRecipe(stack, entry));
-			}
-		} else super.loadCraftingRecipes(outputId, results);
-	}
+    @Override
+    public void drawBackground(int recipe) {
+        super.drawBackground(recipe);
 
-	@Override
-	public void loadCraftingRecipes(ItemStack result) {
-		for(LexiconEntry entry : BotaniaAPI.getAllEntries()) {
-			List<ItemStack> stacks = entry.getDisplayedRecipes();
-			for(ItemStack stack : stacks) {
-				String key1 = LexiconRecipeMappings.stackToString(stack);
-				String key2 = LexiconRecipeMappings.stackToString(result);
-				if(key1.equals(key2))
-					arecipes.add(new CachedLexicaBotaniaRecipe(stack, entry));
-			}
-		}
-	}
+        FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+        CachedLexicaBotaniaRecipe recipeObj = ((CachedLexicaBotaniaRecipe) arecipes.get(recipe));
 
-	@Override
-	public void loadUsageRecipes(ItemStack ingredient) {
-		// NO-OP
-	}
+        renderItem.renderItemAndEffectIntoGUI(font, mc.getTextureManager(), lexicaStack, 51, 5);
+
+        String s = EnumChatFormatting.UNDERLINE + StatCollector.translateToLocal(recipeObj.entry.getUnlocalizedName());
+        font.drawString(s, 82 - font.getStringWidth(s) / 2, 30, 0x404040);
+
+        KnowledgeType type = recipeObj.entry.getKnowledgeType();
+        s = type.color + StatCollector.translateToLocal(type.getUnlocalizedName()).replaceAll("&.", "");
+        font.drawString(s, 82 - font.getStringWidth(s) / 2, 42, 0x404040);
+
+        s = "\"" + StatCollector.translateToLocal(recipeObj.entry.getTagline()) + "\"";
+        PageText.renderText(5, 42, 160, 200, s);
+
+        String key = LexiconRecipeMappings.stackToString(recipeObj.item.item);
+        String quickInfo = "botania.nei.quickInfo:" + key;
+        String quickInfoLocal = StatCollector.translateToLocal(quickInfo);
+
+        if (GuiScreen.isShiftKeyDown() && GuiScreen.isCtrlKeyDown() && Minecraft.getMinecraft().gameSettings.advancedItemTooltips)
+            s = "name: " + key;
+        else if (quickInfo.equals(quickInfoLocal))
+            s = StatCollector.translateToLocal("botania.nei.lexicaNoInfo");
+        else {
+            font.drawString(
+                    StatCollector.translateToLocal("botania.nei.lexicaSeparator"),
+                    82 - font.getStringWidth(s) / 2,
+                    80,
+                    0x404040);
+            s = quickInfoLocal;
+        }
+
+        PageText.renderText(5, 80, 160, 200, s);
+    }
+
+    @Override
+    public void loadCraftingRecipes(String outputId, Object... results) {
+        if (outputId.equals(getOverlayIdentifier())) {
+            for (LexiconEntry entry : BotaniaAPI.getAllEntries()) {
+                List<ItemStack> stacks = entry.getDisplayedRecipes();
+                for (ItemStack stack : stacks)
+                    arecipes.add(new CachedLexicaBotaniaRecipe(stack, entry));
+            }
+        } else {
+            super.loadCraftingRecipes(outputId, results);
+        }
+    }
+
+    @Override
+    public void loadCraftingRecipes(ItemStack result) {
+        for (LexiconEntry entry : BotaniaAPI.getAllEntries()) {
+            List<ItemStack> stacks = entry.getDisplayedRecipes();
+            for (ItemStack stack : stacks) {
+                String key1 = LexiconRecipeMappings.stackToString(stack);
+                String key2 = LexiconRecipeMappings.stackToString(result);
+                if (key1.equals(key2)) {
+                    arecipes.add(new CachedLexicaBotaniaRecipe(stack, entry));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void loadUsageRecipes(String outputId, Object... ingredients) {
+        loadCraftingRecipes(outputId, ingredients);
+    }
+
+    @Override
+    public void loadUsageRecipes(ItemStack ingredient) {
+        loadCraftingRecipes(ingredient);
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
@@ -15,9 +15,7 @@ import java.util.Collection;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -26,16 +24,15 @@ import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.lexicon.KnowledgeType;
 import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.api.lexicon.LexiconRecipeMappings;
+import vazkii.botania.client.integration.nei.NEIHelper;
 import vazkii.botania.client.lib.LibResources;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lexicon.page.PageText;
+import codechicken.lib.gui.GuiDraw;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class RecipeHandlerLexicaBotania extends TemplateRecipeHandler {
-
-    private static final RenderItem renderItem = new RenderItem();
-    private static final Minecraft mc = Minecraft.getMinecraft();
     private static final ItemStack lexicaStack = new ItemStack(ModItems.lexicon);
 
     public class CachedLexicaBotaniaRecipe extends CachedRecipe {
@@ -84,35 +81,48 @@ public class RecipeHandlerLexicaBotania extends TemplateRecipeHandler {
     public void drawBackground(int recipe) {
         super.drawBackground(recipe);
 
-        FontRenderer font = Minecraft.getMinecraft().fontRenderer;
         CachedLexicaBotaniaRecipe recipeObj = ((CachedLexicaBotaniaRecipe) arecipes.get(recipe));
 
-        renderItem.renderItemAndEffectIntoGUI(font, mc.getTextureManager(), lexicaStack, 51, 5);
+        NEIHelper.renderItem.renderItemIntoGUI(NEIHelper.font, NEIHelper.textureManager, lexicaStack, 51, 5);
 
-        String s = EnumChatFormatting.UNDERLINE + StatCollector.translateToLocal(recipeObj.entry.getUnlocalizedName());
-        font.drawString(s, 82 - font.getStringWidth(s) / 2, 30, 0x404040);
+        GuiDraw.drawStringC(
+                EnumChatFormatting.UNDERLINE + StatCollector.translateToLocal(recipeObj.entry.getUnlocalizedName()),
+                82,
+                30,
+                0x404040,
+                false);
 
         KnowledgeType type = recipeObj.entry.getKnowledgeType();
-        s = type.color + StatCollector.translateToLocal(type.getUnlocalizedName()).replaceAll("&.", "");
-        font.drawString(s, 82 - font.getStringWidth(s) / 2, 42, 0x404040);
+        GuiDraw.drawStringC(
+                type.color + StatCollector.translateToLocal(type.getUnlocalizedName()).replaceAll("&.", ""),
+                82,
+                42,
+                0x404040,
+                false);
 
-        s = "\"" + StatCollector.translateToLocal(recipeObj.entry.getTagline()) + "\"";
-        PageText.renderText(5, 42, 160, 200, s);
+        PageText.renderText(
+                5,
+                42,
+                160,
+                200,
+                "\"" + StatCollector.translateToLocal(recipeObj.entry.getTagline()) + "\"");
 
         String key = LexiconRecipeMappings.stackToString(recipeObj.item.item);
         String quickInfo = "botania.nei.quickInfo:" + key;
         String quickInfoLocal = StatCollector.translateToLocal(quickInfo);
 
+        String s;
         if (GuiScreen.isShiftKeyDown() && GuiScreen.isCtrlKeyDown() && Minecraft.getMinecraft().gameSettings.advancedItemTooltips)
             s = "name: " + key;
         else if (quickInfo.equals(quickInfoLocal))
             s = StatCollector.translateToLocal("botania.nei.lexicaNoInfo");
         else {
-            font.drawString(
+            GuiDraw.drawStringC(
                     StatCollector.translateToLocal("botania.nei.lexicaSeparator"),
-                    82 - font.getStringWidth(s) / 2,
+                    82,
                     80,
-                    0x404040);
+                    0x404040,
+                    false);
             s = quickInfoLocal;
         }
 

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
@@ -33,7 +33,7 @@ import codechicken.nei.PositionedStack;
 import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class RecipeHandlerLexicaBotania extends TemplateRecipeHandler {
-    private static final ItemStack lexicaStack = new ItemStack(ModItems.lexicon);
+    private static final ItemStack LEXICA = new ItemStack(ModItems.lexicon);
 
     public class CachedLexicaBotaniaRecipe extends CachedRecipe {
 
@@ -83,7 +83,7 @@ public class RecipeHandlerLexicaBotania extends TemplateRecipeHandler {
 
         CachedLexicaBotaniaRecipe recipeObj = ((CachedLexicaBotaniaRecipe) arecipes.get(recipe));
 
-        NEIHelper.renderItemIntoGUI(lexicaStack, 51, 5);
+        NEIHelper.renderItemIntoGUI(LEXICA, 51, 5);
 
         GuiDraw.drawStringC(
                 EnumChatFormatting.UNDERLINE + StatCollector.translateToLocal(recipeObj.entry.getUnlocalizedName()),

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerLexicaBotania.java
@@ -94,7 +94,7 @@ public class RecipeHandlerLexicaBotania extends TemplateRecipeHandler {
 
         KnowledgeType type = recipeObj.entry.getKnowledgeType();
         GuiDraw.drawStringC(
-                type.color + StatCollector.translateToLocal(type.getUnlocalizedName()).replaceAll("&.", ""),
+                type.color + StatCollector.translateToLocal(type.getUnlocalizedName()).replaceAll("&[0-9a-fklmnor]", ""),
                 82,
                 42,
                 0x404040,

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -115,7 +115,7 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL11.GL_DEPTH_TEST);
         RenderTilePool.forceMana = true;
-        NEIHelper.renderItem.renderItemIntoGUI(NEIHelper.font, NEIHelper.textureManager, poolStack, 71, 37);
+        NEIHelper.renderItemIntoGUI(poolStack, 71, 37);
         GL11.glDisable(GL11.GL_DEPTH_TEST);
         RenderHelper.disableStandardItemLighting();
     }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -82,11 +82,6 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 	}
 
 	@Override
-	public int recipiesPerPage() {
-		return 1;
-	}
-
-	@Override
 	public void loadTransferRects() {
 		transferRects.add(new RecipeTransferRect(new Rectangle(70, 36, 18, 18), "botania.manaPool"));
 	}

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -2,11 +2,8 @@ package vazkii.botania.client.integration.nei.recipe;
 
 import java.awt.Rectangle;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.RenderHelper;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.oredict.OreDictionary;
@@ -16,6 +13,7 @@ import org.lwjgl.opengl.GL11;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.recipe.RecipeManaInfusion;
 import vazkii.botania.client.core.handler.HUDHandler;
+import vazkii.botania.client.integration.nei.NEIHelper;
 import vazkii.botania.client.lib.LibResources;
 import vazkii.botania.client.render.tile.RenderTilePool;
 import vazkii.botania.common.block.ModBlocks;
@@ -27,8 +25,6 @@ import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 
-    private static final RenderItem renderItem = new RenderItem();
-    private static final Minecraft mc = Minecraft.getMinecraft();
     private static final ItemStack poolStack = new ItemStack(ModBlocks.pool);
 
     public class CachedManaPoolRecipe extends CachedRecipe {
@@ -104,17 +100,22 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
         GuiDraw.drawTexturedModalRect(45, 20, 38, 35, 92, 50);
         // Mana bar
         int tempMana = ((CachedManaPoolRecipe) arecipes.get(recipe)).mana;
-        HUDHandler.renderManaBar(32, 80, 0x0000FF, 0.75F, GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10, TilePool.MAX_MANA / 10);
-        FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+        HUDHandler.renderManaBar(
+                32,
+                80,
+                0x0000FF,
+                0.75F,
+                GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10,
+                TilePool.MAX_MANA / 10);
         String size = GuiScreen.isShiftKeyDown() ? "1x " : "10x ";
         String localized = StatCollector.translateToLocal("botaniamisc.neiratio");
-        font.drawString(size + localized, 84 - font.getStringWidth(size + localized) / 2, 71, 0x000000);
+        GuiDraw.drawStringC(size + localized, 84, 71, 0x000000, false);
         GL11.glDisable(GL11.GL_BLEND);
         // Mana pool item
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL11.GL_DEPTH_TEST);
         RenderTilePool.forceMana = true;
-        renderItem.renderItemIntoGUI(font, mc.getTextureManager(), poolStack, 71, 37);
+        NEIHelper.renderItem.renderItemIntoGUI(NEIHelper.font, NEIHelper.textureManager, poolStack, 71, 37);
         GL11.glDisable(GL11.GL_DEPTH_TEST);
         RenderHelper.disableStandardItemLighting();
     }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -1,13 +1,12 @@
 package vazkii.botania.client.integration.nei.recipe;
 
 import java.awt.Rectangle;
-import java.util.ArrayList;
-import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.item.Item;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.oredict.OreDictionary;
@@ -28,115 +27,132 @@ import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 
-	public class CachedManaPoolRecipe extends CachedRecipe {
+    private static final RenderItem renderItem = new RenderItem();
+    private static final Minecraft mc = Minecraft.getMinecraft();
+    private static final ItemStack poolStack = new ItemStack(ModBlocks.pool);
 
-		public List<PositionedStack> inputs = new ArrayList<>();
-		public PositionedStack output;
-		public List<PositionedStack> otherStacks = new ArrayList<>();
-		public int mana;
+    public class CachedManaPoolRecipe extends CachedRecipe {
 
-		public CachedManaPoolRecipe(RecipeManaInfusion recipe) {
-			if(recipe == null)
-				return;
-			inputs.add(new PositionedStack(new ItemStack(ModBlocks.pool, 1, recipe.getOutput().getItem() == Item.getItemFromBlock(ModBlocks.pool) ? 2 : 0), 71, 37));
+        public PositionedStack input;
+        public PositionedStack output;
+        public PositionedStack catalyst;
+        public int mana;
 
-			if(recipe.getInput() instanceof String)
-				inputs.add(new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 37));
-			else inputs.add(new PositionedStack(recipe.getInput(), 42, 37));
+        public CachedManaPoolRecipe(RecipeManaInfusion recipe) {
+            if (recipe == null) return;
 
-			if(recipe.isAlchemy())
-				otherStacks.add(new PositionedStack(new ItemStack(ModBlocks.alchemyCatalyst), 10, 37));
-			else if (recipe.isConjuration())
-				otherStacks.add(new PositionedStack(new ItemStack(ModBlocks.conjurationCatalyst), 10, 37));
+            if (recipe.getInput() instanceof String) {
+                input = new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 37);
+            } else {
+                input = new PositionedStack(recipe.getInput(), 42, 37);
+            }
 
-			output = new PositionedStack(recipe.getOutput(), 101, 37);
-			// This value is where the mana bar is stored initially
-			mana = recipe.getManaToConsume();
-		}
+            if (recipe.isAlchemy()) {
+                catalyst = new PositionedStack(new ItemStack(ModBlocks.alchemyCatalyst), 10, 37);
+            } else if (recipe.isConjuration()) {
+                catalyst = new PositionedStack(new ItemStack(ModBlocks.conjurationCatalyst), 10, 37);
+            }
 
-		@Override
-		public List<PositionedStack> getIngredients() {
-			return inputs;
-		}
+            output = new PositionedStack(recipe.getOutput(), 101, 37);
+            mana = recipe.getManaToConsume();
+        }
 
-		@Override
-		public PositionedStack getResult() {
-			return output;
-		}
+        @Override
+        public PositionedStack getIngredient() {
+            return input;
+        }
 
-		@Override
-		public List<PositionedStack> getOtherStacks() {
-			return otherStacks;
-		}
+        @Override
+        public PositionedStack getResult() {
+            return output;
+        }
 
-	}
+        @Override
+        public PositionedStack getOtherStack() {
+            return catalyst;
+        }
 
-	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.manaPool");
-	}
+    }
 
-	@Override
-	public String getGuiTexture() {
-		return LibResources.GUI_NEI_BLANK;
-	}
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.manaPool");
+    }
 
-	@Override
-	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(70, 36, 18, 18), "botania.manaPool"));
-	}
+    @Override
+    public String getOverlayIdentifier() {
+        return "botania.manaPool";
+    }
 
-	@Override
-	public void drawBackground(int recipe) {
-		super.drawBackground(recipe);
-		GL11.glEnable(GL11.GL_BLEND);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
-		// Mana infusion is the mana pool, super weird.
-		GuiDraw.changeTexture(LibResources.GUI_MANA_INFUSION_OVERLAY);
-		GuiDraw.drawTexturedModalRect(45, 20, 38, 35, 92, 50);
-		// Below is where the mana bar actually drawn.
-		int tempMana = ((CachedManaPoolRecipe) arecipes.get(recipe)).mana;
-		HUDHandler.renderManaBar(32, 80, 0x0000FF, 0.75F, GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10, TilePool.MAX_MANA / 10);
-		FontRenderer font = Minecraft.getMinecraft().fontRenderer;
-		String size = GuiScreen.isShiftKeyDown() ? "1x " : "10x ";
-		String localized = StatCollector.translateToLocal("botaniamisc.neiratio");
-		font.drawString(size + localized, 84 - font.getStringWidth(size + localized) / 2, 71, 0x000000);
-		RenderTilePool.forceMana = true;
-	}
+    @Override
+    public String getGuiTexture() {
+        return LibResources.GUI_NEI_BLANK;
+    }
 
-	@Override
-	public void loadCraftingRecipes(String outputId, Object... results) {
-		if(outputId.equals("botania.manaPool")) {
-			for(RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
-				if(recipe == null)
-					continue;
+    @Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(70, 36, 18, 18), getOverlayIdentifier()));
+    }
 
-				arecipes.add(new CachedManaPoolRecipe(recipe));
-			}
-		} else super.loadCraftingRecipes(outputId, results);
-	}
+    @Override
+    public void drawBackground(int recipe) {
+        super.drawBackground(recipe);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
+        // Arrows
+        GuiDraw.changeTexture(LibResources.GUI_MANA_INFUSION_OVERLAY);
+        GuiDraw.drawTexturedModalRect(45, 20, 38, 35, 92, 50);
+        // Mana bar
+        int tempMana = ((CachedManaPoolRecipe) arecipes.get(recipe)).mana;
+        HUDHandler.renderManaBar(32, 80, 0x0000FF, 0.75F, GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10, TilePool.MAX_MANA / 10);
+        FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+        String size = GuiScreen.isShiftKeyDown() ? "1x " : "10x ";
+        String localized = StatCollector.translateToLocal("botaniamisc.neiratio");
+        font.drawString(size + localized, 84 - font.getStringWidth(size + localized) / 2, 71, 0x000000);
+        GL11.glDisable(GL11.GL_BLEND);
+        // Mana pool item
+        RenderHelper.enableGUIStandardItemLighting();
+        GL11.glEnable(GL11.GL_DEPTH_TEST);
+        RenderTilePool.forceMana = true;
+        renderItem.renderItemIntoGUI(font, mc.getTextureManager(), poolStack, 71, 37);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
+        RenderHelper.disableStandardItemLighting();
+    }
 
-	@Override
-	public void loadCraftingRecipes(ItemStack result) {
-		for(RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
-			if(recipe == null)
-				continue;
+    @Override
+    public void loadCraftingRecipes(String outputId, Object... results) {
+        if (outputId.equals(getOverlayIdentifier())) {
+            for (RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
+                if (recipe == null) continue;
 
-			if(ItemNBTHelper.areStacksSameTypeCraftingWithNBT(recipe.getOutput(), result))
-				arecipes.add(new CachedManaPoolRecipe(recipe));
-		}
-	}
+                arecipes.add(new CachedManaPoolRecipe(recipe));
+            }
+        } else {
+            super.loadCraftingRecipes(outputId, results);
+        }
+    }
 
-	@Override
-	public void loadUsageRecipes(ItemStack ingredient) {
-		for(RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
-			if(recipe == null)
-				continue;
+    @Override
+    public void loadCraftingRecipes(ItemStack result) {
+        for (RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
+            if (recipe == null) continue;
 
-			CachedManaPoolRecipe crecipe = new CachedManaPoolRecipe(recipe);
-			if(ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getIngredients(), ingredient) || ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getOtherStacks(), ingredient))
-				arecipes.add(crecipe);
-		}
-	}
+            if (ItemNBTHelper.areStacksSameTypeCraftingWithNBT(recipe.getOutput(), result)) {
+                arecipes.add(new CachedManaPoolRecipe(recipe));
+            }
+        }
+    }
+
+    @Override
+    public void loadUsageRecipes(ItemStack ingredient) {
+        for (RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
+            if (recipe == null) continue;
+
+            CachedManaPoolRecipe crecipe = new CachedManaPoolRecipe(recipe);
+            if (ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getIngredients(), ingredient) || ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getOtherStacks(), ingredient)) {
+                arecipes.add(crecipe);
+            }
+        }
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -56,7 +56,7 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, inputs);
+			return inputs;
 		}
 
 		@Override

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -2,11 +2,8 @@ package vazkii.botania.client.integration.nei.recipe;
 
 import java.awt.Rectangle;
 
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.RenderHelper;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.oredict.OreDictionary;
@@ -16,6 +13,7 @@ import org.lwjgl.opengl.GL11;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.recipe.RecipeManaInfusion;
 import vazkii.botania.client.core.handler.HUDHandler;
+import vazkii.botania.client.integration.nei.NEIHelper;
 import vazkii.botania.client.lib.LibResources;
 import vazkii.botania.client.render.tile.RenderTilePool;
 import vazkii.botania.common.block.ModBlocks;
@@ -27,8 +25,6 @@ import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 
-    private static final RenderItem renderItem = new RenderItem();
-    private static final Minecraft mc = Minecraft.getMinecraft();
     private static final ItemStack poolStack = new ItemStack(ModBlocks.pool);
 
     public class CachedManaPoolRecipe extends CachedRecipe {
@@ -104,17 +100,22 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
         GuiDraw.drawTexturedModalRect(45, 20, 38, 35, 92, 50);
         // Mana bar
         int tempMana = ((CachedManaPoolRecipe) arecipes.get(recipe)).mana;
-        HUDHandler.renderManaBar(32, 80, 0x0000FF, 0.75F, GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10, TilePool.MAX_MANA / 10);
-        FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+        HUDHandler.renderManaBar(
+                32,
+                80,
+                0x0000FF,
+                0.75F,
+                GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10,
+                TilePool.MAX_MANA / 10);
         String size = GuiScreen.isShiftKeyDown() ? "1x" : "10x";
         String localized = StatCollector.translateToLocalFormatted("botaniamisc.neiratio", size);
-        font.drawString(localized, 84 - font.getStringWidth(localized) / 2, 71, 0x000000);
+        GuiDraw.drawStringC(localized, 84, 71, 0x000000, false);
         GL11.glDisable(GL11.GL_BLEND);
         // Mana pool item
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL11.GL_DEPTH_TEST);
         RenderTilePool.forceMana = true;
-        renderItem.renderItemIntoGUI(font, mc.getTextureManager(), poolStack, 71, 37);
+        NEIHelper.renderItem.renderItemIntoGUI(NEIHelper.font, NEIHelper.textureManager, poolStack, 71, 37);
         GL11.glDisable(GL11.GL_DEPTH_TEST);
         RenderHelper.disableStandardItemLighting();
     }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -152,8 +152,8 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
             if (recipe == null) continue;
 
             CachedManaPoolRecipe crecipe = new CachedManaPoolRecipe(recipe);
-            if ((ItemNBTHelper.positionedStackContainsWithNBT(crecipe.input, ingredient)) ||
-                (ItemNBTHelper.positionedStackContainsWithNBT(crecipe.catalyst, ingredient))) {
+            if (ItemNBTHelper.positionedStackContainsWithNBT(crecipe.input, ingredient) ||
+                ItemNBTHelper.positionedStackContainsWithNBT(crecipe.catalyst, ingredient)) {
                 arecipes.add(crecipe);
             }
         }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -152,7 +152,8 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
             if (recipe == null) continue;
 
             CachedManaPoolRecipe crecipe = new CachedManaPoolRecipe(recipe);
-            if (ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getIngredients(), ingredient) || ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getOtherStacks(), ingredient)) {
+            if ((ItemNBTHelper.positionedStackContainsWithNBT(crecipe.input, ingredient)) ||
+                (ItemNBTHelper.positionedStackContainsWithNBT(crecipe.catalyst, ingredient))) {
                 arecipes.add(crecipe);
             }
         }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -39,11 +39,11 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
         public CachedManaPoolRecipe(RecipeManaInfusion recipe) {
             if (recipe == null) return;
 
-            if (recipe.getInput() instanceof String) {
-                input = new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 37);
-            } else {
-                input = new PositionedStack(recipe.getInput(), 42, 37);
+            Object o = recipe.getInput();
+            if (o instanceof String oreName) {
+                o = OreDictionary.getOres(oreName);
             }
+            input = new PositionedStack(o, 42, 37);
 
             if (recipe.isAlchemy()) {
                 catalyst = ALCHEMY;

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -1,13 +1,12 @@
 package vazkii.botania.client.integration.nei.recipe;
 
 import java.awt.Rectangle;
-import java.util.ArrayList;
-import java.util.List;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.item.Item;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.oredict.OreDictionary;
@@ -28,115 +27,132 @@ import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 
-	public class CachedManaPoolRecipe extends CachedRecipe {
+    private static final RenderItem renderItem = new RenderItem();
+    private static final Minecraft mc = Minecraft.getMinecraft();
+    private static final ItemStack poolStack = new ItemStack(ModBlocks.pool);
 
-		public List<PositionedStack> inputs = new ArrayList<>();
-		public PositionedStack output;
-		public List<PositionedStack> otherStacks = new ArrayList<>();
-		public int mana;
+    public class CachedManaPoolRecipe extends CachedRecipe {
 
-		public CachedManaPoolRecipe(RecipeManaInfusion recipe) {
-			if(recipe == null)
-				return;
-			inputs.add(new PositionedStack(new ItemStack(ModBlocks.pool, 1, recipe.getOutput().getItem() == Item.getItemFromBlock(ModBlocks.pool) ? 2 : 0), 71, 37));
+        public PositionedStack input;
+        public PositionedStack output;
+        public PositionedStack catalyst;
+        public int mana;
 
-			if(recipe.getInput() instanceof String)
-				inputs.add(new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 37));
-			else inputs.add(new PositionedStack(recipe.getInput(), 42, 37));
+        public CachedManaPoolRecipe(RecipeManaInfusion recipe) {
+            if (recipe == null) return;
 
-			if(recipe.isAlchemy())
-				otherStacks.add(new PositionedStack(new ItemStack(ModBlocks.alchemyCatalyst), 10, 37));
-			else if (recipe.isConjuration())
-				otherStacks.add(new PositionedStack(new ItemStack(ModBlocks.conjurationCatalyst), 10, 37));
+            if (recipe.getInput() instanceof String) {
+                input = new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 37);
+            } else {
+                input = new PositionedStack(recipe.getInput(), 42, 37);
+            }
 
-			output = new PositionedStack(recipe.getOutput(), 101, 37);
-			// This value is where the mana bar is stored initially
-			mana = recipe.getManaToConsume();
-		}
+            if (recipe.isAlchemy()) {
+                catalyst = new PositionedStack(new ItemStack(ModBlocks.alchemyCatalyst), 10, 37);
+            } else if (recipe.isConjuration()) {
+                catalyst = new PositionedStack(new ItemStack(ModBlocks.conjurationCatalyst), 10, 37);
+            }
 
-		@Override
-		public List<PositionedStack> getIngredients() {
-			return inputs;
-		}
+            output = new PositionedStack(recipe.getOutput(), 101, 37);
+            mana = recipe.getManaToConsume();
+        }
 
-		@Override
-		public PositionedStack getResult() {
-			return output;
-		}
+        @Override
+        public PositionedStack getIngredient() {
+            return input;
+        }
 
-		@Override
-		public List<PositionedStack> getOtherStacks() {
-			return otherStacks;
-		}
+        @Override
+        public PositionedStack getResult() {
+            return output;
+        }
 
-	}
+        @Override
+        public PositionedStack getOtherStack() {
+            return catalyst;
+        }
 
-	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.manaPool");
-	}
+    }
 
-	@Override
-	public String getGuiTexture() {
-		return LibResources.GUI_NEI_BLANK;
-	}
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.manaPool");
+    }
 
-	@Override
-	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(70, 36, 18, 18), "botania.manaPool"));
-	}
+    @Override
+    public String getOverlayIdentifier() {
+        return "botania.manaPool";
+    }
 
-	@Override
-	public void drawBackground(int recipe) {
-		super.drawBackground(recipe);
-		GL11.glEnable(GL11.GL_BLEND);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
-		// Mana infusion is the mana pool, super weird.
-		GuiDraw.changeTexture(LibResources.GUI_MANA_INFUSION_OVERLAY);
-		GuiDraw.drawTexturedModalRect(45, 20, 38, 35, 92, 50);
-		// Below is where the mana bar actually drawn.
-		int tempMana = ((CachedManaPoolRecipe) arecipes.get(recipe)).mana;
-		HUDHandler.renderManaBar(32, 80, 0x0000FF, 0.75F, GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10, TilePool.MAX_MANA / 10);
-		FontRenderer font = Minecraft.getMinecraft().fontRenderer;
-		String size = GuiScreen.isShiftKeyDown() ? "1x" : "10x";
-		String localized = StatCollector.translateToLocalFormatted("botaniamisc.neiratio", size);
-		font.drawString(localized, 84 - font.getStringWidth(localized) / 2, 71, 0x000000);
-		RenderTilePool.forceMana = true;
-	}
+    @Override
+    public String getGuiTexture() {
+        return LibResources.GUI_NEI_BLANK;
+    }
 
-	@Override
-	public void loadCraftingRecipes(String outputId, Object... results) {
-		if(outputId.equals("botania.manaPool")) {
-			for(RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
-				if(recipe == null)
-					continue;
+    @Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(70, 36, 18, 18), getOverlayIdentifier()));
+    }
 
-				arecipes.add(new CachedManaPoolRecipe(recipe));
-			}
-		} else super.loadCraftingRecipes(outputId, results);
-	}
+    @Override
+    public void drawBackground(int recipe) {
+        super.drawBackground(recipe);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
+        // Arrows
+        GuiDraw.changeTexture(LibResources.GUI_MANA_INFUSION_OVERLAY);
+        GuiDraw.drawTexturedModalRect(45, 20, 38, 35, 92, 50);
+        // Mana bar
+        int tempMana = ((CachedManaPoolRecipe) arecipes.get(recipe)).mana;
+        HUDHandler.renderManaBar(32, 80, 0x0000FF, 0.75F, GuiScreen.isShiftKeyDown() ? tempMana : tempMana * 10, TilePool.MAX_MANA / 10);
+        FontRenderer font = Minecraft.getMinecraft().fontRenderer;
+        String size = GuiScreen.isShiftKeyDown() ? "1x" : "10x";
+        String localized = StatCollector.translateToLocalFormatted("botaniamisc.neiratio", size);
+        font.drawString(localized, 84 - font.getStringWidth(localized) / 2, 71, 0x000000);
+        GL11.glDisable(GL11.GL_BLEND);
+        // Mana pool item
+        RenderHelper.enableGUIStandardItemLighting();
+        GL11.glEnable(GL11.GL_DEPTH_TEST);
+        RenderTilePool.forceMana = true;
+        renderItem.renderItemIntoGUI(font, mc.getTextureManager(), poolStack, 71, 37);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
+        RenderHelper.disableStandardItemLighting();
+    }
 
-	@Override
-	public void loadCraftingRecipes(ItemStack result) {
-		for(RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
-			if(recipe == null)
-				continue;
+    @Override
+    public void loadCraftingRecipes(String outputId, Object... results) {
+        if (outputId.equals(getOverlayIdentifier())) {
+            for (RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
+                if (recipe == null) continue;
 
-			if(ItemNBTHelper.areStacksSameTypeCraftingWithNBT(recipe.getOutput(), result))
-				arecipes.add(new CachedManaPoolRecipe(recipe));
-		}
-	}
+                arecipes.add(new CachedManaPoolRecipe(recipe));
+            }
+        } else {
+            super.loadCraftingRecipes(outputId, results);
+        }
+    }
 
-	@Override
-	public void loadUsageRecipes(ItemStack ingredient) {
-		for(RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
-			if(recipe == null)
-				continue;
+    @Override
+    public void loadCraftingRecipes(ItemStack result) {
+        for (RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
+            if (recipe == null) continue;
 
-			CachedManaPoolRecipe crecipe = new CachedManaPoolRecipe(recipe);
-			if(ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getIngredients(), ingredient) || ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getOtherStacks(), ingredient))
-				arecipes.add(crecipe);
-		}
-	}
+            if (ItemNBTHelper.areStacksSameTypeCraftingWithNBT(recipe.getOutput(), result)) {
+                arecipes.add(new CachedManaPoolRecipe(recipe));
+            }
+        }
+    }
+
+    @Override
+    public void loadUsageRecipes(ItemStack ingredient) {
+        for (RecipeManaInfusion recipe : BotaniaAPI.manaInfusionRecipes) {
+            if (recipe == null) continue;
+
+            CachedManaPoolRecipe crecipe = new CachedManaPoolRecipe(recipe);
+            if (ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getIngredients(), ingredient) || ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getOtherStacks(), ingredient)) {
+                arecipes.add(crecipe);
+            }
+        }
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerManaPool.java
@@ -25,10 +25,12 @@ import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerManaPool extends TemplateRecipeHandler {
 
-    private static final ItemStack poolStack = new ItemStack(ModBlocks.pool);
+    private static final ItemStack POOL = new ItemStack(ModBlocks.pool);
 
     public class CachedManaPoolRecipe extends CachedRecipe {
 
+        private static final PositionedStack ALCHEMY = new PositionedStack(new ItemStack(ModBlocks.alchemyCatalyst), 10, 37);
+        private static final PositionedStack CONJURATION = new PositionedStack(new ItemStack(ModBlocks.conjurationCatalyst), 10, 37);
         public PositionedStack input;
         public PositionedStack output;
         public PositionedStack catalyst;
@@ -44,9 +46,9 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
             }
 
             if (recipe.isAlchemy()) {
-                catalyst = new PositionedStack(new ItemStack(ModBlocks.alchemyCatalyst), 10, 37);
+                catalyst = ALCHEMY;
             } else if (recipe.isConjuration()) {
-                catalyst = new PositionedStack(new ItemStack(ModBlocks.conjurationCatalyst), 10, 37);
+                catalyst = CONJURATION;
             }
 
             output = new PositionedStack(recipe.getOutput(), 101, 37);
@@ -115,7 +117,7 @@ public class RecipeHandlerManaPool extends TemplateRecipeHandler {
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL11.GL_DEPTH_TEST);
         RenderTilePool.forceMana = true;
-        NEIHelper.renderItemIntoGUI(poolStack, 71, 37);
+        NEIHelper.renderItemIntoGUI(POOL, 71, 37);
         GL11.glDisable(GL11.GL_DEPTH_TEST);
         RenderHelper.disableStandardItemLighting();
     }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -115,7 +115,7 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
         if (!((CachedCircleRecipe) arecipes.get(recipe)).renderItem) return;
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL11.GL_DEPTH_TEST);
-        NEIHelper.renderItem.renderItemIntoGUI(NEIHelper.font, NEIHelper.textureManager, getRenderItem(), 73, 55);
+        NEIHelper.renderItemIntoGUI(getRenderItem(), 73, 55);
         GL11.glDisable(GL11.GL_DEPTH_TEST);
         RenderHelper.disableStandardItemLighting();
     }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -86,11 +86,6 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
 	}
 
 	@Override
-	public int recipiesPerPage() {
-		return 1;
-	}
-
-	@Override
 	public void drawBackground(int recipe) {
 		super.drawBackground(recipe);
 		GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -26,16 +26,24 @@ import vazkii.botania.common.core.helper.ItemNBTHelper;
 public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
     private static final ItemStack altarStack = new ItemStack(ModBlocks.altar);
 
-    public abstract class CachedCircleRecipe extends CachedRecipe {
-
+    public class CachedPetalApothecaryRecipe extends CachedRecipe {
         public List<PositionedStack> inputs = new ArrayList<>();
         public PositionedStack output;
         public boolean renderItem;
 
-        public CachedCircleRecipe(RecipePetals recipe) {
+        public CachedPetalApothecaryRecipe(RecipePetals recipe, boolean addCenterItem) {
             setIngredients(recipe.getInputs());
             output = new PositionedStack(recipe.getOutput(), 111, 21);
-            renderItem = true;
+            renderItem = addCenterItem;
+            if (addCenterItem) {
+                ItemStack seedStack = new ItemStack(Items.wheat_seeds);
+                seedStack.setStackDisplayName(StatCollector.translateToLocal("botania.nei.anySeed"));
+                inputs.add(new PositionedStack(seedStack, 73, 39));
+            }
+        }
+
+        public CachedPetalApothecaryRecipe(RecipePetals recipe) {
+            this(recipe, true);
         }
 
         public void setIngredients(List<Object> inputs) {
@@ -66,23 +74,6 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
         }
     }
 
-    public class CachedPetalApothecaryRecipe extends CachedCircleRecipe {
-        ItemStack seedStack = new ItemStack(Items.wheat_seeds);
-
-        public CachedPetalApothecaryRecipe(RecipePetals recipe) {
-            super(recipe);
-            seedStack.setStackDisplayName(StatCollector.translateToLocal("botania.nei.anySeed"));
-            inputs.add(new PositionedStack(seedStack, 73, 39));
-        }
-
-        // Used by the Alfheim addon
-        @SuppressWarnings("unused")
-        public CachedPetalApothecaryRecipe(RecipePetals recipe, boolean addCenterItem) {
-            super(recipe);
-            renderItem = addCenterItem;
-        }
-    }
-
     @Override
     public String getRecipeName() {
         return StatCollector.translateToLocal("botania.nei.petalApothecary");
@@ -90,6 +81,12 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
 
     @Override
     public String getOverlayIdentifier() {
+        return getRecipeID();
+    }
+
+    // Used by the Alfheim addon
+    @Deprecated
+    public String getRecipeID() {
         return "botania.petalApothecary";
     }
 
@@ -112,7 +109,7 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
         GuiDraw.changeTexture(LibResources.GUI_PETAL_OVERLAY);
         GuiDraw.drawTexturedModalRect(45, 10, 38, 7, 92, 92);
         // Item
-        if (!((CachedCircleRecipe) arecipes.get(recipe)).renderItem) return;
+        if (!((CachedPetalApothecaryRecipe) arecipes.get(recipe)).renderItem) return;
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL11.GL_DEPTH_TEST);
         NEIHelper.renderItemIntoGUI(getRenderItem(), 73, 55);
@@ -128,8 +125,8 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
         return BotaniaAPI.petalRecipes;
     }
 
-    public CachedCircleRecipe getCachedRecipe(RecipePetals recipe) {
-        return new CachedPetalApothecaryRecipe(recipe);
+    public CachedPetalApothecaryRecipe getCachedRecipe(RecipePetals recipe) {
+        return new CachedPetalApothecaryRecipe(recipe, true);
     }
 
     @Override
@@ -159,7 +156,7 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
         for (RecipePetals recipe : getRecipes()) {
             if (recipe == null) continue;
 
-            CachedCircleRecipe crecipe = getCachedRecipe(recipe);
+            CachedPetalApothecaryRecipe crecipe = getCachedRecipe(recipe);
             if (ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.inputs, ingredient) && recipe.getOutput().getItem() != Items.skull) {
                 arecipes.add(crecipe);
             }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -56,7 +56,7 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, inputs);
+			return inputs;
 		}
 
 		@Override

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -4,6 +4,7 @@ import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
@@ -13,6 +14,7 @@ import org.lwjgl.opengl.GL11;
 
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.recipe.RecipePetals;
+import vazkii.botania.client.integration.nei.NEIHelper;
 import vazkii.botania.client.lib.LibResources;
 import vazkii.botania.common.block.ModBlocks;
 import codechicken.lib.gui.GuiDraw;
@@ -22,117 +24,146 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
+    private static final ItemStack altarStack = new ItemStack(ModBlocks.altar);
 
-	public class CachedPetalApothecaryRecipe extends CachedRecipe {
+    public abstract class CachedCircleRecipe extends CachedRecipe {
 
-		public List<PositionedStack> inputs = new ArrayList<>();
-		public PositionedStack output;
+        public List<PositionedStack> inputs = new ArrayList<>();
+        public PositionedStack output;
+        public boolean renderItem;
 
-		public CachedPetalApothecaryRecipe(RecipePetals recipe, boolean addCenterItem) {
-			setIngredients(recipe.getInputs());
-			output = new PositionedStack(recipe.getOutput(), 111, 21);
-			if(addCenterItem)
-				inputs.add(new PositionedStack(new ItemStack(ModBlocks.altar), 73, 55));
-		}
+        public CachedCircleRecipe(RecipePetals recipe) {
+            setIngredients(recipe.getInputs());
+            output = new PositionedStack(recipe.getOutput(), 111, 21);
+            renderItem = true;
+        }
 
-		public CachedPetalApothecaryRecipe(RecipePetals recipe) {
-			this(recipe, true);
-		}
+        public void setIngredients(List<Object> inputs) {
+            float degreePerInput = 360F / inputs.size();
+            float currentDegree = -90F;
 
-		public void setIngredients(List<Object> inputs) {
-			float degreePerInput = 360F / inputs.size();
-			float currentDegree = -90F;
+            for (Object o : inputs) {
+                int posX = (int) Math.round(73 + Math.cos(currentDegree * Math.PI / 180D) * 32);
+                int posY = (int) Math.round(55 + Math.sin(currentDegree * Math.PI / 180D) * 32);
 
-			for(Object o : inputs) {
-				int posX = (int) Math.round(73 + Math.cos(currentDegree * Math.PI / 180D) * 32);
-				int posY = (int) Math.round(55 + Math.sin(currentDegree * Math.PI / 180D) * 32);
+                if (o instanceof String) {
+                    this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), posX, posY));
+                } else {
+                    this.inputs.add(new PositionedStack(o, posX, posY));
+                }
+                currentDegree += degreePerInput;
+            }
+        }
 
-				if(o instanceof String)
-					this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), posX, posY));
-				else this.inputs.add(new PositionedStack(o, posX, posY));
-				currentDegree += degreePerInput;
-			}
-		}
+        @Override
+        public List<PositionedStack> getIngredients() {
+            return inputs;
+        }
 
-		@Override
-		public List<PositionedStack> getIngredients() {
-			return inputs;
-		}
+        @Override
+        public PositionedStack getResult() {
+            return output;
+        }
+    }
 
-		@Override
-		public PositionedStack getResult() {
-			return output;
-		}
+    public class CachedPetalApothecaryRecipe extends CachedCircleRecipe {
+        ItemStack seedStack = new ItemStack(Items.wheat_seeds);
 
-	}
+        public CachedPetalApothecaryRecipe(RecipePetals recipe) {
+            super(recipe);
+            seedStack.setStackDisplayName(StatCollector.translateToLocal("botania.nei.anySeed"));
+            inputs.add(new PositionedStack(seedStack, 73, 39));
+        }
 
-	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.petalApothecary");
-	}
+        // Used by the Alfheim addon
+        @SuppressWarnings("unused")
+        public CachedPetalApothecaryRecipe(RecipePetals recipe, boolean addCenterItem) {
+            super(recipe);
+            renderItem = addCenterItem;
+        }
+    }
 
-	public String getRecipeID() {
-		return "botania.petalApothecary";
-	}
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.petalApothecary");
+    }
 
-	@Override
-	public String getGuiTexture() {
-		return LibResources.GUI_NEI_BLANK;
-	}
+    @Override
+    public String getOverlayIdentifier() {
+        return "botania.petalApothecary";
+    }
 
-	@Override
-	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(72, 54, 18, 18), getRecipeID()));
-	}
+    @Override
+    public String getGuiTexture() {
+        return LibResources.GUI_NEI_BLANK;
+    }
 
-	@Override
-	public void drawBackground(int recipe) {
-		super.drawBackground(recipe);
-		GL11.glEnable(GL11.GL_BLEND);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
-		GuiDraw.changeTexture(LibResources.GUI_PETAL_OVERLAY);
-		GuiDraw.drawTexturedModalRect(45, 10, 38, 7, 92, 92);
-	}
+    @Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(73, 56, 16, 16), getOverlayIdentifier()));
+    }
 
-	public List<? extends RecipePetals> getRecipes() {
-		return BotaniaAPI.petalRecipes;
-	}
+    @Override
+    public void drawBackground(int recipe) {
+        super.drawBackground(recipe);
+        // Background circle graphic
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
+        GuiDraw.changeTexture(LibResources.GUI_PETAL_OVERLAY);
+        GuiDraw.drawTexturedModalRect(45, 10, 38, 7, 92, 92);
+        // Item
+        if (!((CachedCircleRecipe) arecipes.get(recipe)).renderItem) return;
+        RenderHelper.enableGUIStandardItemLighting();
+        GL11.glEnable(GL11.GL_DEPTH_TEST);
+        NEIHelper.renderItem.renderItemIntoGUI(NEIHelper.font, NEIHelper.textureManager, getRenderItem(), 73, 55);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
+        RenderHelper.disableStandardItemLighting();
+    }
 
-	public CachedPetalApothecaryRecipe getCachedRecipe(RecipePetals recipe) {
-		return new CachedPetalApothecaryRecipe(recipe);
-	}
+    protected ItemStack getRenderItem() {
+        return altarStack;
+    }
 
-	@Override
-	public void loadCraftingRecipes(String outputId, Object... results) {
-		if(outputId.equals(getRecipeID())) {
-			for(RecipePetals recipe : getRecipes())
-				if(recipe.getOutput().getItem() != Items.skull)
-					arecipes.add(getCachedRecipe(recipe));
-		} else super.loadCraftingRecipes(outputId, results);
-	}
+    public List<? extends RecipePetals> getRecipes() {
+        return BotaniaAPI.petalRecipes;
+    }
 
-	@Override
-	public void loadCraftingRecipes(ItemStack result) {
-		for(RecipePetals recipe : getRecipes()){
-			if(recipe == null)
-				continue;
+    public CachedCircleRecipe getCachedRecipe(RecipePetals recipe) {
+        return new CachedPetalApothecaryRecipe(recipe);
+    }
 
-			if(recipe.getOutput().stackTagCompound != null && ItemNBTHelper.areStacksSameTypeWithNBT(recipe.getOutput(), result) || recipe.getOutput().stackTagCompound == null && NEIServerUtils.areStacksSameTypeCrafting(recipe.getOutput(), result) && recipe.getOutput().getItem() != Items.skull)
-				arecipes.add(getCachedRecipe(recipe));
-		}
-	}
+    @Override
+    public void loadCraftingRecipes(String outputId, Object... results) {
+        if (outputId.equals(getOverlayIdentifier())) {
+            for (RecipePetals recipe : getRecipes())
+                if (recipe.getOutput().getItem() != Items.skull)
+                    arecipes.add(getCachedRecipe(recipe));
+        } else {
+            super.loadCraftingRecipes(outputId, results);
+        }
+    }
 
-	@Override
-	public void loadUsageRecipes(ItemStack ingredient) {
-		for(RecipePetals recipe : getRecipes()) {
-			if(recipe == null)
-				continue;
+    @Override
+    public void loadCraftingRecipes(ItemStack result) {
+        for (RecipePetals recipe : getRecipes()) {
+            if (recipe == null) continue;
 
-			CachedPetalApothecaryRecipe crecipe = getCachedRecipe(recipe);
-			if(ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.inputs, ingredient) && recipe.getOutput().getItem() != Items.skull)
-				arecipes.add(crecipe);
-		}
-	}
+            if (recipe.getOutput().stackTagCompound != null && ItemNBTHelper.areStacksSameTypeWithNBT(recipe.getOutput(), result) || recipe.getOutput().stackTagCompound == null && NEIServerUtils.areStacksSameTypeCrafting(recipe.getOutput(), result) && recipe.getOutput().getItem() != Items.skull) {
+                arecipes.add(getCachedRecipe(recipe));
+            }
+        }
+    }
 
+    @Override
+    public void loadUsageRecipes(ItemStack ingredient) {
+        for (RecipePetals recipe : getRecipes()) {
+            if (recipe == null) continue;
+
+            CachedCircleRecipe crecipe = getCachedRecipe(recipe);
+            if (ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.inputs, ingredient) && recipe.getOutput().getItem() != Items.skull) {
+                arecipes.add(crecipe);
+            }
+        }
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -51,10 +51,9 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
                 int posY = (int) Math.round(55 + Math.sin(currentDegree * Math.PI / 180D) * 32);
 
                 if (o instanceof String oreName) {
-                    this.inputs.add(new PositionedStack(OreDictionary.getOres(oreName), posX, posY));
-                } else {
-                    this.inputs.add(new PositionedStack(o, posX, posY));
+                    o = OreDictionary.getOres(oreName);
                 }
+                this.inputs.add(new PositionedStack(o, posX, posY));
                 currentDegree += degreePerInput;
             }
         }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -24,7 +24,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
-    private static final ItemStack altarStack = new ItemStack(ModBlocks.altar);
+    private static final ItemStack APOTHECARY = new ItemStack(ModBlocks.altar);
 
     public class CachedPetalApothecaryRecipe extends CachedRecipe {
         public List<PositionedStack> inputs = new ArrayList<>();
@@ -118,7 +118,7 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
     }
 
     protected ItemStack getRenderItem() {
-        return altarStack;
+        return APOTHECARY;
     }
 
     public List<? extends RecipePetals> getRecipes() {

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -74,10 +74,10 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
 
     @Override
     public String getOverlayIdentifier() {
-        return getRecipeID();
+        return "botania.petalApothecary";
     }
 
-    // Used by the Alfheim addon
+    // Used by the Alfheim addon, identical to getOverlayIdentifier()
     @Deprecated
     public String getRecipeID() {
         return "botania.petalApothecary";

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -31,15 +31,13 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
         public PositionedStack output;
 
         public CachedPetalApothecaryRecipe(RecipePetals recipe, PositionedStack centerItem) {
-            setIngredients(recipe.getInputs());
-            output = new PositionedStack(recipe.getOutput(), 111, 21);
-            if (centerItem != null) {
-                inputs.add(centerItem);
-            }
+            this(recipe);
+            inputs.add(centerItem);
         }
 
         public CachedPetalApothecaryRecipe(RecipePetals recipe) {
-            this(recipe, null);
+            setIngredients(recipe.getInputs());
+            output = new PositionedStack(recipe.getOutput(), 111, 21);
         }
 
         public void setIngredients(List<Object> inputs) {

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPetalApothecary.java
@@ -29,21 +29,17 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
     public class CachedPetalApothecaryRecipe extends CachedRecipe {
         public List<PositionedStack> inputs = new ArrayList<>();
         public PositionedStack output;
-        public boolean renderItem;
 
-        public CachedPetalApothecaryRecipe(RecipePetals recipe, boolean addCenterItem) {
+        public CachedPetalApothecaryRecipe(RecipePetals recipe, PositionedStack centerItem) {
             setIngredients(recipe.getInputs());
             output = new PositionedStack(recipe.getOutput(), 111, 21);
-            renderItem = addCenterItem;
-            if (addCenterItem) {
-                ItemStack seedStack = new ItemStack(Items.wheat_seeds);
-                seedStack.setStackDisplayName(StatCollector.translateToLocal("botania.nei.anySeed"));
-                inputs.add(new PositionedStack(seedStack, 73, 39));
+            if (centerItem != null) {
+                inputs.add(centerItem);
             }
         }
 
         public CachedPetalApothecaryRecipe(RecipePetals recipe) {
-            this(recipe, true);
+            this(recipe, null);
         }
 
         public void setIngredients(List<Object> inputs) {
@@ -54,8 +50,8 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
                 int posX = (int) Math.round(73 + Math.cos(currentDegree * Math.PI / 180D) * 32);
                 int posY = (int) Math.round(55 + Math.sin(currentDegree * Math.PI / 180D) * 32);
 
-                if (o instanceof String) {
-                    this.inputs.add(new PositionedStack(OreDictionary.getOres((String) o), posX, posY));
+                if (o instanceof String oreName) {
+                    this.inputs.add(new PositionedStack(OreDictionary.getOres(oreName), posX, posY));
                 } else {
                     this.inputs.add(new PositionedStack(o, posX, posY));
                 }
@@ -109,7 +105,6 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
         GuiDraw.changeTexture(LibResources.GUI_PETAL_OVERLAY);
         GuiDraw.drawTexturedModalRect(45, 10, 38, 7, 92, 92);
         // Item
-        if (!((CachedPetalApothecaryRecipe) arecipes.get(recipe)).renderItem) return;
         RenderHelper.enableGUIStandardItemLighting();
         GL11.glEnable(GL11.GL_DEPTH_TEST);
         NEIHelper.renderItemIntoGUI(getRenderItem(), 73, 55);
@@ -126,7 +121,9 @@ public class RecipeHandlerPetalApothecary extends TemplateRecipeHandler {
     }
 
     public CachedPetalApothecaryRecipe getCachedRecipe(RecipePetals recipe) {
-        return new CachedPetalApothecaryRecipe(recipe, true);
+        ItemStack seedStack = new ItemStack(Items.wheat_seeds);
+        seedStack.setStackDisplayName(StatCollector.translateToLocal("botania.nei.anySeed"));
+        return new CachedPetalApothecaryRecipe(recipe, new PositionedStack(seedStack, 73, 39));
     }
 
     @Override

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
@@ -13,6 +13,7 @@ import org.lwjgl.opengl.GL11;
 
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.recipe.RecipePureDaisy;
+import vazkii.botania.client.integration.nei.NEIHelper;
 import vazkii.botania.client.lib.LibResources;
 import vazkii.botania.common.core.helper.ItemNBTHelper;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
@@ -23,98 +24,107 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class RecipeHandlerPureDaisy extends TemplateRecipeHandler {
 
-	public class CachedPureDaisyRecipe extends CachedRecipe {
+    private static final ItemStack flowerStack = ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_PUREDAISY);
 
-		public List<PositionedStack> inputs = new ArrayList<>();
-		public PositionedStack output;
-		public List<PositionedStack> otherStacks = new ArrayList<>();
+    public class CachedPureDaisyRecipe extends CachedRecipe {
 
-		public CachedPureDaisyRecipe(RecipePureDaisy recipe) {
-			if(recipe == null)
-				return;
-			inputs.add(new PositionedStack(ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_PUREDAISY), 71, 23));
+        public List<PositionedStack> inputs = new ArrayList<>();
+        public PositionedStack output;
+        public List<PositionedStack> otherStacks = new ArrayList<>();
 
-			if(recipe.getInput() instanceof String)
-				inputs.add(new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 23));
-			else inputs.add(new PositionedStack(new ItemStack((Block) recipe.getInput()), 42, 23));
+        public CachedPureDaisyRecipe(RecipePureDaisy recipe) {
+            if (recipe == null) return;
 
-			output = new PositionedStack(new ItemStack(recipe.getOutput()), 101, 23);
-		}
+            if (recipe.getInput() instanceof String) {
+                inputs.add(new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 23));
+            } else {
+                inputs.add(new PositionedStack(new ItemStack((Block) recipe.getInput()), 42, 23));
+            }
 
-		@Override
-		public List<PositionedStack> getIngredients() {
-			return inputs;
-		}
+            output = new PositionedStack(new ItemStack(recipe.getOutput()), 101, 23);
+        }
 
-		@Override
-		public PositionedStack getResult() {
-			return output;
-		}
+        @Override
+        public List<PositionedStack> getIngredients() {
+            return inputs;
+        }
 
-		@Override
-		public List<PositionedStack> getOtherStacks() {
-			return otherStacks;
-		}
+        @Override
+        public PositionedStack getResult() {
+            return output;
+        }
 
-	}
+        @Override
+        public List<PositionedStack> getOtherStacks() {
+            return otherStacks;
+        }
 
-	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.pureDaisy");
-	}
+    }
 
-	@Override
-	public String getGuiTexture() {
-		return LibResources.GUI_NEI_BLANK;
-	}
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.pureDaisy");
+    }
 
 	@Override
-	public void loadTransferRects() {
-		transferRects.add(new RecipeTransferRect(new Rectangle(70, 22, 18, 18), "botania.pureDaisy"));
+	public String getOverlayIdentifier() {
+		return "botania.pureDaisy";
 	}
 
-	@Override
-	public void drawBackground(int recipe) {
-		super.drawBackground(recipe);
-		GL11.glEnable(GL11.GL_BLEND);
-		GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
-		GuiDraw.changeTexture(LibResources.GUI_PURE_DAISY_OVERLAY);
-		GuiDraw.drawTexturedModalRect(45, 10, 0, 0, 65, 44);
-	}
+    @Override
+    public String getGuiTexture() {
+        return LibResources.GUI_NEI_BLANK;
+    }
 
-	@Override
-	public void loadCraftingRecipes(String outputId, Object... results) {
-		if(outputId.equals("botania.pureDaisy")) {
-			for(RecipePureDaisy recipe : BotaniaAPI.pureDaisyRecipes) {
-				if(recipe == null)
-					continue;
+    @Override
+    public void loadTransferRects() {
+        transferRects.add(new RecipeTransferRect(new Rectangle(70, 22, 18, 18), getOverlayIdentifier()));
+    }
 
-				arecipes.add(new CachedPureDaisyRecipe(recipe));
-			}
-		} else super.loadCraftingRecipes(outputId, results);
-	}
+    @Override
+    public void drawBackground(int recipe) {
+        super.drawBackground(recipe);
+        // Arrows
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.5F);
+        GuiDraw.changeTexture(LibResources.GUI_PURE_DAISY_OVERLAY);
+        GuiDraw.drawTexturedModalRect(48, 10, 0, 0, 65, 44);
+        // Flower item
+        NEIHelper.renderItemIntoGUI(flowerStack, 71, 23);
+    }
 
-	@Override
-	public void loadCraftingRecipes(ItemStack result) {
-		for(RecipePureDaisy recipe : BotaniaAPI.pureDaisyRecipes) {
-			if(recipe == null)
-				continue;
+    @Override
+    public void loadCraftingRecipes(String outputId, Object... results) {
+        if (outputId.equals(getOverlayIdentifier())) {
+            for (RecipePureDaisy recipe : BotaniaAPI.pureDaisyRecipes) {
+                if (recipe != null) arecipes.add(new CachedPureDaisyRecipe(recipe));
+            }
+        } else {
+            super.loadCraftingRecipes(outputId, results);
+        }
+    }
 
-			if(ItemNBTHelper.areStacksSameTypeCraftingWithNBT(new ItemStack(recipe.getOutput()), result))
-				arecipes.add(new CachedPureDaisyRecipe(recipe));
-		}
-	}
+    @Override
+    public void loadCraftingRecipes(ItemStack result) {
+        for (RecipePureDaisy recipe : BotaniaAPI.pureDaisyRecipes) {
+            if (recipe == null) continue;
 
-	@Override
-	public void loadUsageRecipes(ItemStack ingredient) {
-		for(RecipePureDaisy recipe : BotaniaAPI.pureDaisyRecipes) {
-			if(recipe == null)
-				continue;
+            if (ItemNBTHelper.areStacksSameTypeCraftingWithNBT(new ItemStack(recipe.getOutput()), result)) {
+                arecipes.add(new CachedPureDaisyRecipe(recipe));
+            }
+        }
+    }
 
-			CachedPureDaisyRecipe crecipe = new CachedPureDaisyRecipe(recipe);
-			if(ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getIngredients(), ingredient) || ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getOtherStacks(), ingredient))
-				arecipes.add(crecipe);
-		}
-	}
+    @Override
+    public void loadUsageRecipes(ItemStack ingredient) {
+        for (RecipePureDaisy recipe : BotaniaAPI.pureDaisyRecipes) {
+            if (recipe == null) continue;
+
+            CachedPureDaisyRecipe crecipe = new CachedPureDaisyRecipe(recipe);
+            if (ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getIngredients(), ingredient) || ItemNBTHelper.cachedRecipeContainsWithNBT(crecipe.getOtherStacks(), ingredient)) {
+                arecipes.add(crecipe);
+            }
+        }
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
@@ -43,7 +43,7 @@ public class RecipeHandlerPureDaisy extends TemplateRecipeHandler {
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, inputs);
+			return inputs;
 		}
 
 		@Override

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
@@ -69,11 +69,6 @@ public class RecipeHandlerPureDaisy extends TemplateRecipeHandler {
 	}
 
 	@Override
-	public int recipiesPerPage() {
-		return 2;
-	}
-
-	@Override
 	public void loadTransferRects() {
 		transferRects.add(new RecipeTransferRect(new Rectangle(70, 22, 18, 18), "botania.pureDaisy"));
 	}

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
@@ -32,12 +32,13 @@ public class RecipeHandlerPureDaisy extends TemplateRecipeHandler {
         public CachedPureDaisyRecipe(RecipePureDaisy recipe) {
             if (recipe == null) return;
 
-            if (recipe.getInput() instanceof String oreName) {
-                inputs = new PositionedStack(OreDictionary.getOres(oreName), 42, 23);
+            Object o = recipe.getInput();
+            if (o instanceof String oreName) {
+                o = OreDictionary.getOres(oreName);
             } else {
-                inputs = new PositionedStack(new ItemStack((Block) recipe.getInput()), 42, 23);
+                o = new ItemStack((Block) o);
             }
-
+            inputs = new PositionedStack(o, 42, 23);
             output = new PositionedStack(new ItemStack(recipe.getOutput()), 101, 23);
         }
 

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
@@ -24,7 +24,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class RecipeHandlerPureDaisy extends TemplateRecipeHandler {
 
-    private static final ItemStack flowerStack = ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_PUREDAISY);
+    private static final ItemStack DAISY = ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_PUREDAISY);
 
     public class CachedPureDaisyRecipe extends CachedRecipe {
 
@@ -90,7 +90,7 @@ public class RecipeHandlerPureDaisy extends TemplateRecipeHandler {
         GuiDraw.changeTexture(LibResources.GUI_PURE_DAISY_OVERLAY);
         GuiDraw.drawTexturedModalRect(48, 10, 0, 0, 65, 44);
         // Flower item
-        NEIHelper.renderItemIntoGUI(flowerStack, 71, 23);
+        NEIHelper.renderItemIntoGUI(DAISY, 71, 23);
     }
 
     @Override

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerPureDaisy.java
@@ -1,8 +1,6 @@
 package vazkii.botania.client.integration.nei.recipe;
 
 import java.awt.Rectangle;
-import java.util.ArrayList;
-import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
@@ -28,35 +26,29 @@ public class RecipeHandlerPureDaisy extends TemplateRecipeHandler {
 
     public class CachedPureDaisyRecipe extends CachedRecipe {
 
-        public List<PositionedStack> inputs = new ArrayList<>();
+        public PositionedStack inputs;
         public PositionedStack output;
-        public List<PositionedStack> otherStacks = new ArrayList<>();
 
         public CachedPureDaisyRecipe(RecipePureDaisy recipe) {
             if (recipe == null) return;
 
-            if (recipe.getInput() instanceof String) {
-                inputs.add(new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 23));
+            if (recipe.getInput() instanceof String oreName) {
+                inputs = new PositionedStack(OreDictionary.getOres(oreName), 42, 23);
             } else {
-                inputs.add(new PositionedStack(new ItemStack((Block) recipe.getInput()), 42, 23));
+                inputs = new PositionedStack(new ItemStack((Block) recipe.getInput()), 42, 23);
             }
 
             output = new PositionedStack(new ItemStack(recipe.getOutput()), 101, 23);
         }
 
         @Override
-        public List<PositionedStack> getIngredients() {
+        public PositionedStack getIngredient() {
             return inputs;
         }
 
         @Override
         public PositionedStack getResult() {
             return output;
-        }
-
-        @Override
-        public List<PositionedStack> getOtherStacks() {
-            return otherStacks;
         }
 
     }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerRunicAltar.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerRunicAltar.java
@@ -16,15 +16,16 @@ public class RecipeHandlerRunicAltar extends RecipeHandlerPetalApothecary {
 
     private static final ItemStack altarStack = new ItemStack(ModBlocks.runeAltar);
 
-    public class CachedRunicAltarRecipe extends CachedCircleRecipe {
+    public class CachedRunicAltarRecipe extends CachedPetalApothecaryRecipe {
 
         public int manaUsage;
 		private static final PositionedStack livingrock = new PositionedStack(new ItemStack(ModBlocks.livingrock), 73, 39);
 
         public CachedRunicAltarRecipe(RecipeRuneAltar recipe) {
-            super(recipe);
+            super(recipe, false);
             inputs.add(livingrock);
             manaUsage = recipe.getManaUsage();
+            renderItem = true;
         }
     }
 
@@ -50,7 +51,7 @@ public class RecipeHandlerRunicAltar extends RecipeHandlerPetalApothecary {
     }
 
     @Override
-    public CachedCircleRecipe getCachedRecipe(RecipePetals recipe) {
+    public CachedPetalApothecaryRecipe getCachedRecipe(RecipePetals recipe) {
         return new CachedRunicAltarRecipe((RecipeRuneAltar) recipe);
     }
 

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerRunicAltar.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerRunicAltar.java
@@ -14,44 +14,49 @@ import codechicken.nei.PositionedStack;
 
 public class RecipeHandlerRunicAltar extends RecipeHandlerPetalApothecary {
 
-	public class CachedRunicAltarRecipe extends CachedPetalApothecaryRecipe {
+    private static final ItemStack altarStack = new ItemStack(ModBlocks.runeAltar);
 
-		public int manaUsage;
+    public class CachedRunicAltarRecipe extends CachedCircleRecipe {
 
-		public CachedRunicAltarRecipe(RecipeRuneAltar recipe) {
-			super(recipe, false);
-			if(recipe == null)
-				return;
-			manaUsage = recipe.getManaUsage();
-			inputs.add(new PositionedStack(new ItemStack(ModBlocks.runeAltar), 73, 55));
-		}
+        public int manaUsage;
+		private static final PositionedStack livingrock = new PositionedStack(new ItemStack(ModBlocks.livingrock), 73, 39);
 
-	}
+        public CachedRunicAltarRecipe(RecipeRuneAltar recipe) {
+            super(recipe);
+            inputs.add(livingrock);
+            manaUsage = recipe.getManaUsage();
+        }
+    }
+
+    @Override
+    public String getRecipeName() {
+        return StatCollector.translateToLocal("botania.nei.runicAltar");
+    }
+
+    @Override
+    public String getOverlayIdentifier() {
+        return "botania.runicAltar";
+    }
+
+    @Override
+    public void drawBackground(int recipe) {
+        super.drawBackground(recipe);
+        HUDHandler.renderManaBar(32, 113, 0x0000FF, 0.75F, ((CachedRunicAltarRecipe) arecipes.get(recipe)).manaUsage, TilePool.MAX_MANA / 10);
+    }
+
+    @Override
+    public List<? extends RecipePetals> getRecipes() {
+        return BotaniaAPI.runeAltarRecipes;
+    }
+
+    @Override
+    public CachedCircleRecipe getCachedRecipe(RecipePetals recipe) {
+        return new CachedRunicAltarRecipe((RecipeRuneAltar) recipe);
+    }
 
 	@Override
-	public String getRecipeName() {
-		return StatCollector.translateToLocal("botania.nei.runicAltar");
-	}
-
-	@Override
-	public String getRecipeID() {
-		return "botania.runicAltar";
-	}
-
-	@Override
-	public void drawBackground(int recipe) {
-		super.drawBackground(recipe);
-		HUDHandler.renderManaBar(32, 113, 0x0000FF, 0.75F, ((CachedRunicAltarRecipe) arecipes.get(recipe)).manaUsage, TilePool.MAX_MANA / 10);
-	}
-
-	@Override
-	public List<? extends RecipePetals> getRecipes() {
-		return BotaniaAPI.runeAltarRecipes;
-	}
-
-	@Override
-	public CachedPetalApothecaryRecipe getCachedRecipe(RecipePetals recipe) {
-		return new CachedRunicAltarRecipe((RecipeRuneAltar) recipe);
-	}
+    protected ItemStack getRenderItem() {
+        return altarStack;
+    }
 
 }

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerRunicAltar.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerRunicAltar.java
@@ -20,13 +20,10 @@ public class RecipeHandlerRunicAltar extends RecipeHandlerPetalApothecary {
     public class CachedRunicAltarRecipe extends CachedPetalApothecaryRecipe {
 
         public int manaUsage;
-		private static final PositionedStack livingrock = new PositionedStack(new ItemStack(ModBlocks.livingrock), 73, 39);
 
-        public CachedRunicAltarRecipe(RecipeRuneAltar recipe) {
-            super(recipe, false);
-            inputs.add(livingrock);
+        public CachedRunicAltarRecipe(RecipeRuneAltar recipe, PositionedStack centerItem) {
+            super(recipe, centerItem);
             manaUsage = recipe.getManaUsage();
-            renderItem = true;
         }
     }
 

--- a/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerRunicAltar.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/recipe/RecipeHandlerRunicAltar.java
@@ -14,7 +14,8 @@ import codechicken.nei.PositionedStack;
 
 public class RecipeHandlerRunicAltar extends RecipeHandlerPetalApothecary {
 
-    private static final ItemStack altarStack = new ItemStack(ModBlocks.runeAltar);
+    private static final ItemStack ALTAR = new ItemStack(ModBlocks.runeAltar);
+    private static final PositionedStack LIVINGROCK = new PositionedStack(new ItemStack(ModBlocks.livingrock), 73, 39);
 
     public class CachedRunicAltarRecipe extends CachedPetalApothecaryRecipe {
 
@@ -52,12 +53,12 @@ public class RecipeHandlerRunicAltar extends RecipeHandlerPetalApothecary {
 
     @Override
     public CachedPetalApothecaryRecipe getCachedRecipe(RecipePetals recipe) {
-        return new CachedRunicAltarRecipe((RecipeRuneAltar) recipe);
+        return new CachedRunicAltarRecipe((RecipeRuneAltar) recipe, LIVINGROCK);
     }
 
 	@Override
     protected ItemStack getRenderItem() {
-        return altarStack;
+        return ALTAR;
     }
 
 }

--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -43,6 +43,7 @@ public class Botania {
 	public static boolean etFuturumLoaded = false;
 	public static boolean storageDrawersLoaded = false;
 	public static boolean structureLibLoaded = false;
+	public static boolean neiLoaded = false;
 
 	public static ILightHelper lightHelper;
 
@@ -63,6 +64,7 @@ public class Botania {
 		etFuturumLoaded = Loader.isModLoaded("etfuturum");
 		storageDrawersLoaded = Loader.isModLoaded("StorageDrawers");
 		structureLibLoaded = Loader.isModLoaded("structurelib");
+		neiLoaded = Loader.isModLoaded("NotEnoughItems");
 		
 		lightHelper = coloredLightsLoaded ? new LightHelperColored() : new LightHelperVanilla();
 		proxy.preInit(event);

--- a/src/main/java/vazkii/botania/common/core/helper/ItemNBTHelper.java
+++ b/src/main/java/vazkii/botania/common/core/helper/ItemNBTHelper.java
@@ -22,7 +22,6 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Set;
 
 public final class ItemNBTHelper {
 
@@ -221,6 +220,7 @@ public final class ItemNBTHelper {
 	 * NBT-friendly version of {@link codechicken.nei.recipe.TemplateRecipeHandler.CachedRecipe#contains(Collection, ItemStack)}
 	 */
 	public static boolean cachedRecipeContainsWithNBT(Collection<PositionedStack> ingredients, ItemStack ingredient) {
+		if (ingredients == null) return false;
 		for (PositionedStack stack : ingredients)
 			if (positionedStackContainsWithNBT(stack, ingredient))
 				return true;
@@ -232,6 +232,7 @@ public final class ItemNBTHelper {
 	 * NBT-friendly version of {@link codechicken.nei.PositionedStack#contains(ItemStack)}
 	 */
 	public static boolean positionedStackContainsWithNBT(PositionedStack stack, ItemStack ingredient) {
+		if (stack == null) return false;
 		for(ItemStack item : stack.items)
 			if(areStacksSameTypeCraftingWithNBT(item, ingredient))
 				return true;

--- a/src/main/java/vazkii/botania/common/core/proxy/CommonProxy.java
+++ b/src/main/java/vazkii/botania/common/core/proxy/CommonProxy.java
@@ -155,7 +155,7 @@ public class CommonProxy {
 
 		LexiconData.init();
 
-		if (Loader.isModLoaded("NotEnoughItems")) {
+		if (Botania.neiLoaded) {
 			IMCForNEI.IMCSender();
 		}
 	}

--- a/src/main/java/vazkii/botania/common/core/proxy/CommonProxy.java
+++ b/src/main/java/vazkii/botania/common/core/proxy/CommonProxy.java
@@ -33,6 +33,7 @@ import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.lexicon.ITwoNamedPage;
 import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.api.lexicon.LexiconPage;
+import vazkii.botania.client.integration.nei.IMCForNEI;
 import vazkii.botania.common.Botania;
 import vazkii.botania.common.achievement.ModAchievements;
 import vazkii.botania.common.block.ModBlocks;
@@ -84,6 +85,7 @@ import vazkii.botania.common.world.SkyblockWorldEvents;
 import vazkii.botania.common.world.WorldTypeSkyblock;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -152,6 +154,10 @@ public class CommonProxy {
 			new StatementAPIPlugin();
 
 		LexiconData.init();
+
+		if (Loader.isModLoaded("NotEnoughItems")) {
+			IMCForNEI.IMCSender();
+		}
 	}
 
 	public void postInit(FMLPostInitializationEvent event) {

--- a/src/main/java/vazkii/botania/common/core/proxy/CommonProxy.java
+++ b/src/main/java/vazkii/botania/common/core/proxy/CommonProxy.java
@@ -85,7 +85,6 @@ import vazkii.botania.common.world.SkyblockWorldEvents;
 import vazkii.botania.common.world.WorldTypeSkyblock;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.FMLLog;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemFlightTiara.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemFlightTiara.java
@@ -10,13 +10,12 @@
  */
 package vazkii.botania.common.item.equipment.bauble;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.List;
-
-import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
@@ -121,44 +120,47 @@ public class ItemFlightTiara extends ItemBauble implements IManaUsingItem, IBaub
 		infoList.add(StatCollector.translateToLocal("botania.wings" + stack.getItemDamage()));
 	}
 
+	/**
+	 * The original solution for "16E1BDFD1D6AE1A954C9C5E1B2D9099780F3E1724541F1F2F77310B769CFFBAC" has been lost
+	 * to time. It's supposed to be a 19 character long Matrix reference, but hash() is broken and gives
+	 * inconsistent output, so it probably wouldn't even be recognized if you got it right. It was later
+	 * replaced with the name of an Aqours single, but the name is too long for anvils in 1.7.10.
+	 * It has been fixed to be consistent (and considerably simplified since doing weird random obfuscation before
+	 * hashing is pointless at best), but it required replacing it with my own solution.
+	 * If you have the original solution, I will gladly replace this one with it.
+	 * Here are a few hints:
+	 * It's the title of a song that aligns with Vazkii's interests.
+	 * For authenticity, this song was released before this secret was originally added (2015).
+	 * This song has a special segment only present in one of the single-member versions.
+	 * -koolkrafter5
+	 */
 	@Override
 	public void onEquipped(ItemStack stack, EntityLivingBase player) {
 		super.onEquipped(stack, player);
-		if(stack.getItemDamage() != WING_TYPES && hash(stack.getDisplayName()).equals("16E1BDFD1D6AE1A954C9C5E1B2D9099780F3E1724541F1F2F77310B769CFFBAC")) {
+		if(stack.getItemDamage() != WING_TYPES && hash(stack.getDisplayName()).equals("04E789FA6BC538F7645606141A1CFECECF4E84C301CB892779E761FD3FFF6386")) {
 			stack.setItemDamage(WING_TYPES);
 			stack.getTagCompound().removeTag("display");
 		}
 	}
 
 	String hash(String str) {
-		if(str != null)
-			try {
-				MessageDigest md = MessageDigest.getInstance("SHA-256");
-				return new HexBinaryAdapter().marshal(md.digest(salt(str).getBytes()));
-			} catch (NoSuchAlgorithmException e) {
-				e.printStackTrace();
-			}
-		return "";
+		if (str == null) {
+			return "";
+		}
+
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(salt(str).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().withUpperCase().formatHex(digest);
+		} catch (NoSuchAlgorithmException e) {
+			e.printStackTrace();
+			return "";
+		}
 	}
 
 	// Might as well be called sugar given it's not secure at all :D
 	String salt(String str) {
-		str = str += "wowsuchsaltmuchsecurityverywow";
-		SecureRandom rand = new SecureRandom(str.getBytes());
-		int l = str.length();
-		int steps = rand.nextInt(l);
-		char[] chrs = str.toCharArray();
-		for(int i = 0; i < steps; i++) {
-			int indA = rand.nextInt(l);
-			int indB;
-			do {
-				indB = rand.nextInt(l);
-			} while(indB == indA);
-			char c = (char) (chrs[indA] ^ chrs[indB]);
-			chrs[indA] = c;
-		}
-
-		return String.copyValueOf(chrs);
+		return str + "wowsuchsaltmuchsecurityverywow";
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemFlightTiara.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemFlightTiara.java
@@ -137,17 +137,14 @@ public class ItemFlightTiara extends ItemBauble implements IManaUsingItem, IBaub
 	@Override
 	public void onEquipped(ItemStack stack, EntityLivingBase player) {
 		super.onEquipped(stack, player);
-		if(stack.getItemDamage() != WING_TYPES && hash(stack.getDisplayName()).equals("04E789FA6BC538F7645606141A1CFECECF4E84C301CB892779E761FD3FFF6386")) {
+		if (stack.getItemDamage() != WING_TYPES &&
+				hash(stack.getDisplayName()).equals("04E789FA6BC538F7645606141A1CFECECF4E84C301CB892779E761FD3FFF6386")) {
 			stack.setItemDamage(WING_TYPES);
 			stack.getTagCompound().removeTag("display");
 		}
 	}
 
 	String hash(String str) {
-		if (str == null) {
-			return "";
-		}
-
 		try {
 			MessageDigest md = MessageDigest.getInstance("SHA-256");
             byte[] digest = md.digest(salt(str).getBytes(StandardCharsets.UTF_8));

--- a/src/main/resources/assets/botania/lang/en_US.lang
+++ b/src/main/resources/assets/botania/lang/en_US.lang
@@ -184,6 +184,8 @@ botania.nei.pureDaisy=Pure Daisy
 botania.nei.lexica=Lexica Botania
 nei.options.keys.gui.botania_corporea_request=Corporea Request
 
+botania.nei.anySeed=Any Seed
+
 botania.nei.lexicaSeparator=Extra Info:
 botania.nei.lexicaNoInfo=(there's no Extra Info for this entry, sorry!)
 


### PR DESCRIPTION
See the commit messages for all improvements.

Highlights:
Show lexicon entries when finding uses *or* recipes for items.
Let the Floating Flower handler use the overlay button to autocomplete recipes in the inventory/crafting table grid.
Fix transfer rects and prevent machines like the Mana Pool and Runic Altar from being added to bookmarked recipes for most handlers by rendering them in the background graphics step instead of adding them to the ingredients of the recipe.
Add seeds/livingrock to apothecary/runic handlers with a custom tooltip for seeds (can be changed with a lang key):
<img width="911" height="542" alt="image" src="https://github.com/user-attachments/assets/b4878c9d-db13-4b1d-94eb-8c0675aff483" />
<img width="608" height="583" alt="image" src="https://github.com/user-attachments/assets/f09aca9e-cf41-447f-ad07-58099f0aa337" />

Most changes are fixing whitespace. Check [this](https://github.blog/news-insights/product-news/ignore-white-space-in-code-review/) out to ignore the whitespace changes when reviewing. We really need to enable spotless because we will never actually sync with or contribute to upstream Botania from this fork due to the radical differences between them. New features already need to be backported manually (like the [improvements to the Rosa Arcana](https://github.com/GTNewHorizons/Botania/pull/109/)) rather than being able to just cherrypick a commit or two.

GTNH's full pack works fine with these changes. I also already tested this with the Alfheim addon and needed to walk back some of my changes to make it work, since it extends the Petal Apothecary handler and what I can only assume is Kotlin nonsense didn't like my changes even though it should have been compatible. If somebody has a better solution that axes the stupid addCenterItem param for CachedPetalApothecaryRecipe and CachedRunicAltarRecipe, I'm all ears.