### PR TITLE
Fix Ring of Mantle re-applying Haste every tick

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemMiningRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemMiningRing.java
@@ -36,10 +36,9 @@ public class ItemMiningRing extends ItemBauble implements IManaUsingItem {
 			if(!hasMana)
 				onUnequipped(stack, player);
 			else {
-				if(player.getActivePotionEffect(Potion.digSpeed) != null)
-					player.removePotionEffect(Potion.digSpeed.id);
-
-				player.addPotionEffect(new PotionEffect(Potion.digSpeed.id, Integer.MAX_VALUE, 1, true));
+				PotionEffect currentEffect = player.getActivePotionEffect(Potion.digSpeed);
+				if(currentEffect == null || currentEffect.getAmplifier() < 1)
+					player.addPotionEffect(new PotionEffect(Potion.digSpeed.id, Integer.MAX_VALUE, 1, true));
 			}
 
 			if(player.swingProgress == 0.25F)


### PR DESCRIPTION
## What

The Ring of Mantle was removing and re-adding the Haste II potion effect
every single tick, even when the player already had it. This caused
unnecessary CPU overhead and FPS drops.

Now it checks if the player already has Haste with amplifier >= 1 before
applying, so the effect is only added once and left alone after that.

## Testing

- Wore the ring with mana available — Haste II applied once, no flickering
- Removed ring — Haste removed as expected
- Ran out of mana — Haste removed as expected
- Used milk bucket to clear effect — ring re-applied it next tick

Fixes GTNewHorizons/GT-New-Horizons-Modpack#23501