### PR TITLE
Pottable flowers and mushrooms

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     api('com.github.GTNewHorizons:Baubles-Expanded:2.2.14-GTNH:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.11.34:dev')
+    implementation('com.github.GTNewHorizons:GTNHLib:0.11.34:dev')
 
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.60:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.7.10:dev') {transitive=false}
@@ -14,7 +14,6 @@ dependencies {
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.4.1:dev")
     compileOnly("com.github.GTNewHorizons:StructureLib:1.4.34:dev")
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     api('com.github.GTNewHorizons:Baubles-Expanded:2.2.14-GTNH:dev')
-    api('com.github.GTNewHorizons:GTNHLib:0.11.30:dev')
+    api('com.github.GTNewHorizons:GTNHLib:0.11.34:dev')
 
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.60:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:ForgeMultipart:1.7.10:dev') {transitive=false}
@@ -14,7 +14,7 @@ dependencies {
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
 
-
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ServerUtilities:2.4.1:dev")
     compileOnly("com.github.GTNewHorizons:StructureLib:1.4.34:dev")
 }
 

--- a/src/main/java/vazkii/botania/client/render/block/RenderSpecialFlower.java
+++ b/src/main/java/vazkii/botania/client/render/block/RenderSpecialFlower.java
@@ -36,11 +36,11 @@ public class RenderSpecialFlower implements ISimpleBlockRenderingHandler, IMulti
 
 	@Override
 	public boolean renderWorldBlock(IBlockAccess blockAccess, int x, int y, int z, Block block, int modelId, RenderBlocks renderer) {
-		return renderCrossedSquares(blockAccess, block, x, y, z, renderer);
+		return renderCrossedSquares(blockAccess, block, x, y, z, 1.0F, true, renderer);
 	}
 
 	// Copied from RenderBlocks
-	public static boolean renderCrossedSquares(IBlockAccess blockAccess, Block block, int x, int y, int z, RenderBlocks render) {
+	public static boolean renderCrossedSquares(IBlockAccess blockAccess, Block block, int x, int y, int z, float scale, boolean doRandomShift, RenderBlocks render) {
 		Tessellator tessellator = Tessellator.instance;
 		tessellator.setBrightness(block.getMixedBrightnessForBlock(blockAccess, x, y, z));
 		float f = 1.0F;
@@ -64,16 +64,17 @@ public class RenderSpecialFlower implements ISimpleBlockRenderingHandler, IMulti
 		double d0 = z;
 		long sh;
 
-		sh = x * 3129871 ^ z * 116129781L ^ y;
-		sh = sh * sh * 42317861L + sh * 11L;
-		d1 += ((sh >> 16 & 15L) / 15.0F - 0.5D) * 0.3D;
-		d2 += (sh >> 32 & 15L) / 15.0F * -0.15D;
-		d0 += ((sh >> 24 & 15L) / 15.0F - 0.5D) * 0.3D;
-
+		if (doRandomShift) {
+			sh = x * 3129871 ^ z * 116129781L ^ y;
+			sh = sh * sh * 42317861L + sh * 11L;
+			d1 += ((sh >> 16 & 15L) / 15.0F - 0.5D) * 0.3D;
+			d2 += (sh >> 32 & 15L) / 15.0F * -0.15D;
+			d0 += ((sh >> 24 & 15L) / 15.0F - 0.5D) * 0.3D;
+		}
 
 		// Only change here, to use xyz rather than side/meta
 		IIcon icon = render.getBlockIcon(block, blockAccess, x, y, z, 0);
-		drawCrossedSquares(blockAccess, block, icon, x, y, z, d1, d2, d0, 1.0F, render);
+		drawCrossedSquares(blockAccess, block, icon, x, y, z, d1, d2, d0, scale, render);
 
 		return true;
 	}

--- a/src/main/java/vazkii/botania/common/block/BlockModFlower.java
+++ b/src/main/java/vazkii/botania/common/block/BlockModFlower.java
@@ -10,12 +10,16 @@
  */
 package vazkii.botania.common.block;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFlower;
 import net.minecraft.block.IGrowable;
+import net.minecraft.client.renderer.RenderBlocks;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.item.EntityItem;
@@ -23,13 +27,16 @@ import net.minecraft.entity.passive.EntitySheep;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.stats.Achievement;
 import net.minecraft.util.IIcon;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import vazkii.botania.api.lexicon.ILexiconable;
 import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.client.core.helper.IconHelper;
 import vazkii.botania.client.lib.LibRenderIDs;
+import vazkii.botania.client.render.block.RenderSpecialFlower;
 import vazkii.botania.common.Botania;
 import vazkii.botania.common.achievement.IPickupAchievement;
 import vazkii.botania.common.achievement.ModAchievements;
@@ -42,7 +49,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public class BlockModFlower extends BlockFlower implements ILexiconable, IPickupAchievement, IGrowable {
+public class BlockModFlower extends BlockFlower implements ILexiconable, IPickupAchievement, IGrowable, IFlowerPottable {
 
 	public static IIcon[] icons;
 	public static IIcon[] iconsAlt;
@@ -156,4 +163,12 @@ public class BlockModFlower extends BlockFlower implements ILexiconable, IPickup
 		world.setBlock(x, y + 1, z, flower, placeMeta | 8, flags);
 	}
 
+	@Override
+	public boolean renderFlowerPot(NBTTagCompound compound, IBlockAccess blockAccess, Block block, int x, int y, int z, RenderBlocks render) {
+		Tessellator tess = Tessellator.instance;
+		tess.addTranslation(0, 4F / 16F, 0);
+		boolean b = RenderSpecialFlower.renderCrossedSquares(blockAccess, block, x, y, z, 0.75F, false, render);
+		tess.addTranslation(0, -4F / 16F, 0);
+		return b;
+	}
 }

--- a/src/main/java/vazkii/botania/common/block/decor/BlockModMushroom.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockModMushroom.java
@@ -13,6 +13,7 @@ package vazkii.botania.common.block.decor;
 import java.util.List;
 import java.util.Random;
 
+import com.gtnewhorizon.gtnhlib.api.IFlowerPottable;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockMushroom;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -44,7 +45,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @Optional.Interface(modid = "Thaumcraft", iface = "thaumcraft.api.crafting.IInfusionStabiliser", striprefs = true)
-public class BlockModMushroom extends BlockMushroom implements IInfusionStabiliser, IHornHarvestable, ILexiconable {
+public class BlockModMushroom extends BlockMushroom implements IInfusionStabiliser, IHornHarvestable, ILexiconable, IFlowerPottable {
 
 	public static IIcon[] icons;
 	public int originalLight;


### PR DESCRIPTION
## Summary
<img width="1757" height="377" alt="image" src="https://github.com/user-attachments/assets/ea22fdf4-a9a4-4e29-8c4b-fb69d9920d33" />
Lets you put botania flowers and mushrooms in flower pots. I wanted to do all the special flowers too, but I think I would need to rewrite IFlowerPottable's mixins.

I modified the rendering methods slightly to allow me to tweak the scale and to allow me to disable the random offsets that Botania normally renders flowers at.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
