### PR TITLE
Cache reflection

### DIFF
--- a/src/main/java/vazkii/botania/client/core/handler/CorporeaAutoCompleteHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/CorporeaAutoCompleteHandler.java
@@ -10,6 +10,7 @@
  */
 package vazkii.botania.client.core.handler;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -30,12 +31,15 @@ import org.lwjgl.input.Keyboard;
 
 import vazkii.botania.api.corporea.CorporeaHelper;
 import vazkii.botania.common.lib.LibObfuscation;
+import vazkii.botania.utils.ReflectionUtils;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.ClientTickEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
-import cpw.mods.fml.relauncher.ReflectionHelper;
 
 public class CorporeaAutoCompleteHandler {
+
+	private static final Field COMPLETE_FLAG = ReflectionUtils.findField(GuiChat.class, LibObfuscation.COMPLETE_FLAG);
+	private static final Field INPUT_FIELD = ReflectionUtils.findField(GuiChat.class, LibObfuscation.INPUT_FIELD);
 
 	boolean isAutoCompleted = false;
 	String originalString = "";
@@ -83,7 +87,7 @@ public class CorporeaAutoCompleteHandler {
 		}
 		GuiChat chat = (GuiChat) screen;
 		if(isAutoCompleted) {
-			boolean valid = ReflectionHelper.getPrivateValue(GuiChat.class, chat, LibObfuscation.COMPLETE_FLAG);
+			boolean valid = ReflectionUtils.getBoolean(COMPLETE_FLAG, chat);
 			if(!valid)
 				isAutoCompleted = false;
 		}
@@ -99,7 +103,7 @@ public class CorporeaAutoCompleteHandler {
 		if(!CorporeaHelper.shouldAutoComplete())
 			return;
 
-		GuiTextField inputField = ReflectionHelper.getPrivateValue(GuiChat.class, chat, LibObfuscation.INPUT_FIELD);
+		GuiTextField inputField = (GuiTextField) ReflectionUtils.getObject(INPUT_FIELD, chat);
 		if(!isAutoCompleted)
 			buildAutoCompletes(inputField, chat);
 		if(isAutoCompleted && !completions.isEmpty())
@@ -127,7 +131,7 @@ public class CorporeaAutoCompleteHandler {
 		if(completions.isEmpty())
 			return;
 		position = -1;
-		ReflectionHelper.setPrivateValue(GuiChat.class, chat, true, LibObfuscation.COMPLETE_FLAG);
+		ReflectionUtils.setBoolean(COMPLETE_FLAG, chat, true);
 		StringBuilder stringbuilder = new StringBuilder();
 		CompletionData data;
 		for(Iterator<CompletionData> iterator = completions.iterator(); iterator.hasNext(); stringbuilder.append(data.string)) {

--- a/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
@@ -11,6 +11,7 @@
 package vazkii.botania.client.core.handler;
 
 import java.awt.Color;
+import java.lang.reflect.Field;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
@@ -65,14 +66,16 @@ import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.equipment.bauble.ItemFlightTiara;
 import vazkii.botania.common.item.equipment.bauble.ItemMonocle;
 import vazkii.botania.common.lib.LibObfuscation;
+import vazkii.botania.utils.ReflectionUtils;
 import baubles.common.lib.PlayerHandler;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.relauncher.ReflectionHelper;
 
 public final class HUDHandler {
 
 	public static final ResourceLocation manaBar = new ResourceLocation(LibResources.GUI_MANA_HUD);
+
+	private static final Field REMAINING_HIGHLIGHT_TICKS = ReflectionUtils.findField(GuiIngame.class, LibObfuscation.REMAINING_HIGHLIGHT_TICKS);
 
 	@SubscribeEvent(priority = EventPriority.HIGHEST)
 	public void onDrawScreenPre(RenderGameOverlayEvent.Pre event) {
@@ -221,7 +224,7 @@ public final class HUDHandler {
 		Profiler profiler = mc.mcProfiler;
 
 		profiler.startSection("wandMode");
-		int ticks = ReflectionHelper.getPrivateValue(GuiIngame.class, mc.ingameGUI, LibObfuscation.REMAINING_HIGHLIGHT_TICKS);
+		int ticks = ReflectionUtils.getInt(REMAINING_HIGHLIGHT_TICKS, mc.ingameGUI);
 		ticks -= 15;
 		if(ticks > 0) {
 			int alpha = Math.min(255, (int) (ticks * 256.0F / 10.0F));

--- a/src/main/java/vazkii/botania/client/core/handler/TooltipAdditionDisplayHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/TooltipAdditionDisplayHandler.java
@@ -11,6 +11,7 @@
 package vazkii.botania.client.core.handler;
 
 import java.awt.Color;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,9 +40,11 @@ import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.item.ItemLexicon;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lib.LibObfuscation;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import vazkii.botania.utils.ReflectionUtils;
 
 public final class TooltipAdditionDisplayHandler {
+
+	private static final Field THE_SLOT = ReflectionUtils.findField(GuiContainer.class, LibObfuscation.THE_SLOT);
 
 	private static float lexiconLookupTime = 0F;
 
@@ -50,7 +53,7 @@ public final class TooltipAdditionDisplayHandler {
 		GuiScreen gui = mc.currentScreen;
 		if(gui != null && gui instanceof GuiContainer && mc.thePlayer != null && mc.thePlayer.inventory.getItemStack() == null) {
 			GuiContainer container = (GuiContainer) gui;
-			Slot slot = ReflectionHelper.getPrivateValue(GuiContainer.class, container, LibObfuscation.THE_SLOT);
+			Slot slot = (Slot) ReflectionUtils.getObject(THE_SLOT, container);
 			if(slot != null && slot.getHasStack()) {
 				ItemStack stack = slot.getStack();
 				if(stack != null) {

--- a/src/main/java/vazkii/botania/client/render/item/RenderBow.java
+++ b/src/main/java/vazkii/botania/client/render/item/RenderBow.java
@@ -10,6 +10,8 @@
  */
 package vazkii.botania.client.render.item;
 
+import java.lang.reflect.Field;
+
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
@@ -20,9 +22,12 @@ import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
 import vazkii.botania.common.lib.LibObfuscation;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import vazkii.botania.utils.ReflectionUtils;
 
 public class RenderBow implements IItemRenderer {
+
+	private static final Field ITEM_IN_USE = ReflectionUtils.findField(EntityPlayer.class, LibObfuscation.ITEM_IN_USE);
+	private static final Field ITEM_IN_USE_COUNT = ReflectionUtils.findField(EntityPlayer.class, LibObfuscation.ITEM_IN_USE_COUNT);
 
 	@Override
 	public boolean handleRenderType(ItemStack item, ItemRenderType type) {
@@ -62,8 +67,11 @@ public class RenderBow implements IItemRenderer {
 		int dmg = item.getItemDamage();
 		IIcon icon = item.getItem().getIconFromDamageForRenderPass(dmg, 0);
 		if(player != null) {
-			ItemStack using = ReflectionHelper.getPrivateValue(EntityPlayer.class, player, LibObfuscation.ITEM_IN_USE);
-			int time = ReflectionHelper.getPrivateValue(EntityPlayer.class, player, LibObfuscation.ITEM_IN_USE_COUNT);
+			ItemStack using = (ItemStack) ReflectionUtils.getObject(ITEM_IN_USE, player);
+			int time = 0;
+			Object timeObj = ReflectionUtils.getObject(ITEM_IN_USE_COUNT, player);
+			if(timeObj != null)
+				time = (Integer) timeObj;
 			icon = item.getItem().getIcon(item, 0, player, using, time);
 			if(transform) {
 				GL11.glTranslatef(0.2F, -0.3F, 0.1F);

--- a/src/main/java/vazkii/botania/client/render/world/SkyblockSkyRenderer.java
+++ b/src/main/java/vazkii/botania/client/render/world/SkyblockSkyRenderer.java
@@ -10,6 +10,7 @@
  */
 package vazkii.botania.client.render.world;
 
+import java.lang.reflect.Field;
 import java.util.Random;
 
 import net.minecraft.client.Minecraft;
@@ -28,7 +29,7 @@ import org.lwjgl.opengl.GL11;
 import vazkii.botania.client.core.handler.ClientTickHandler;
 import vazkii.botania.client.lib.LibResources;
 import vazkii.botania.common.lib.LibObfuscation;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import vazkii.botania.utils.ReflectionUtils;
 
 public class SkyblockSkyRenderer extends IRenderHandler {
 
@@ -45,11 +46,14 @@ public class SkyblockSkyRenderer extends IRenderHandler {
 		new ResourceLocation(LibResources.MISC_PLANET + "5.png")
 	};
 
+	private static final Field GL_SKY_LIST = ReflectionUtils.findField(RenderGlobal.class, LibObfuscation.GL_SKY_LIST);
+	private static final Field STAR_GL_CALL_LIST = ReflectionUtils.findField(RenderGlobal.class, LibObfuscation.STAR_GL_CALL_LIST);
+
 	@Override
 	public void render(float partialTicks, WorldClient world, Minecraft mc) {
 
-		int glSkyList = ReflectionHelper.getPrivateValue(RenderGlobal.class, mc.renderGlobal, LibObfuscation.GL_SKY_LIST);
-		int starGLCallList = ReflectionHelper.getPrivateValue(RenderGlobal.class, mc.renderGlobal, LibObfuscation.STAR_GL_CALL_LIST);
+		int glSkyList = ReflectionUtils.getInt(GL_SKY_LIST, mc.renderGlobal);
+		int starGLCallList = ReflectionUtils.getInt(STAR_GL_CALL_LIST, mc.renderGlobal);
 
 		GL11.glDisable(GL11.GL_TEXTURE_2D);
 		Vec3 vec3 = world.getSkyColor(mc.renderViewEntity, partialTicks);

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTilePollidisiac.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTilePollidisiac.java
@@ -10,6 +10,7 @@
  */
 package vazkii.botania.common.block.subtile.functional;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 import net.minecraft.entity.item.EntityItem;
@@ -21,9 +22,11 @@ import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.lexicon.LexiconData;
 import vazkii.botania.common.lib.LibObfuscation;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import vazkii.botania.utils.ReflectionUtils;
 
 public class SubTilePollidisiac extends SubTileFunctional {
+
+	private static final Field IN_LOVE = ReflectionUtils.findField(EntityAnimal.class, LibObfuscation.IN_LOVE);
 
 	private static final int RANGE = 6;
 
@@ -42,7 +45,7 @@ public class SubTilePollidisiac extends SubTileFunctional {
 				if(mana < manaCost)
 					break;
 
-				int love = ReflectionHelper.getPrivateValue(EntityAnimal.class, animal, LibObfuscation.IN_LOVE);
+				int love = ReflectionUtils.getInt(IN_LOVE, animal);
 				if(animal.getGrowingAge() == 0 && love <= 0) {
 					for(EntityItem item : items) {
 						if(item.age < (60 + slowdown) || item.isDead)
@@ -56,7 +59,7 @@ public class SubTilePollidisiac extends SubTileFunctional {
 
 							mana -= manaCost;
 
-							ReflectionHelper.setPrivateValue(EntityAnimal.class, animal, 1200, LibObfuscation.IN_LOVE);
+							ReflectionUtils.setInt(IN_LOVE, animal, 1200);
 							animal.setTarget(null);
 							supertile.getWorldObj().setEntityState(animal, (byte)18);
 						}

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileTigerseye.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileTigerseye.java
@@ -10,6 +10,7 @@
  */
 package vazkii.botania.common.block.subtile.functional;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,9 +28,13 @@ import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.lexicon.LexiconData;
 import vazkii.botania.common.lib.LibObfuscation;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import vazkii.botania.utils.ReflectionUtils;
 
 public class SubTileTigerseye extends SubTileFunctional {
+
+	private static final Field TIME_SINCE_IGNITED = ReflectionUtils.findField(EntityCreeper.class, LibObfuscation.TIME_SINCE_IGNITED);
+	private static final Field TARGET_ENTITY_CLASS = ReflectionUtils.findField(EntityAIAvoidEntity.class, LibObfuscation.TARGET_ENTITY_CLASS);
+	private static final Field TARGET_CLASS = ReflectionUtils.findField(EntityAINearestAttackableTarget.class, LibObfuscation.TARGET_CLASS);
 
 	private static final int RANGE = 10;
 	private static final int RANGE_Y = 4;
@@ -58,7 +63,7 @@ public class SubTileTigerseye extends SubTileFunctional {
 				}
 
 			if(entity instanceof EntityCreeper) {
-				ReflectionHelper.setPrivateValue(EntityCreeper.class, (EntityCreeper) entity, 2, LibObfuscation.TIME_SINCE_IGNITED);
+				ReflectionUtils.setInt(TIME_SINCE_IGNITED, entity, 2);
 				entity.setAttackTarget(null);
 			}
 
@@ -71,16 +76,16 @@ public class SubTileTigerseye extends SubTileFunctional {
 	}
 
 	private boolean messWithRunAwayAI(EntityAIAvoidEntity aiEntry) {
-		if(ReflectionHelper.getPrivateValue(EntityAIAvoidEntity.class, aiEntry, LibObfuscation.TARGET_ENTITY_CLASS) == EntityOcelot.class) {
-			ReflectionHelper.setPrivateValue(EntityAIAvoidEntity.class, aiEntry, EntityPlayer.class, LibObfuscation.TARGET_ENTITY_CLASS);
+		if(ReflectionUtils.getObject(TARGET_ENTITY_CLASS, aiEntry) == EntityOcelot.class) {
+			ReflectionUtils.setObject(TARGET_ENTITY_CLASS, aiEntry, EntityPlayer.class);
 			return true;
 		}
 		return false;
 	}
 
 	private void messWithGetTargetAI(EntityAINearestAttackableTarget aiEntry) {
-		if(ReflectionHelper.getPrivateValue(EntityAINearestAttackableTarget.class, aiEntry, LibObfuscation.TARGET_CLASS) == EntityPlayer.class)
-			ReflectionHelper.setPrivateValue(EntityAINearestAttackableTarget.class, aiEntry, EntityEnderCrystal.class, LibObfuscation.TARGET_CLASS); // Something random that won't be around
+		if(ReflectionUtils.getObject(TARGET_CLASS, aiEntry) == EntityPlayer.class)
+			ReflectionUtils.setObject(TARGET_CLASS, aiEntry, EntityEnderCrystal.class); // Something random that won't be around
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/tile/TileSpawnerClaw.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileSpawnerClaw.java
@@ -10,6 +10,7 @@
  */
 package vazkii.botania.common.block.tile;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 import net.minecraft.entity.Entity;
@@ -24,11 +25,18 @@ import net.minecraft.util.WeightedRandom;
 import vazkii.botania.api.mana.IManaReceiver;
 import vazkii.botania.common.Botania;
 import vazkii.botania.common.lib.LibObfuscation;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import vazkii.botania.utils.ReflectionUtils;
 
 public class TileSpawnerClaw extends TileMod implements IManaReceiver {
 
 	private static final String TAG_MANA = "mana";
+
+	private static final Field SPAWN_COUNT = ReflectionUtils.findField(MobSpawnerBaseLogic.class, LibObfuscation.SPAWN_COUNT);
+	private static final Field SPAWN_RANGE = ReflectionUtils.findField(MobSpawnerBaseLogic.class, LibObfuscation.SPAWN_RANGE);
+	private static final Field MAX_NEARBY_ENTITIES = ReflectionUtils.findField(MobSpawnerBaseLogic.class, LibObfuscation.MAX_NEARBY_ENTITIES);
+	private static final Field MAX_SPAWN_DELAY = ReflectionUtils.findField(MobSpawnerBaseLogic.class, LibObfuscation.MAX_SPAWN_DELAY);
+	private static final Field MIN_SPAWN_DELAY = ReflectionUtils.findField(MobSpawnerBaseLogic.class, LibObfuscation.MIN_SPAWN_DELAY);
+	private static final Field POTENTIAL_ENTITY_SPAWNS = ReflectionUtils.findField(MobSpawnerBaseLogic.class, LibObfuscation.POTENTIAL_ENTITY_SPAWNS);
 
 	int mana = 0;
 
@@ -61,9 +69,9 @@ public class TileSpawnerClaw extends TileMod implements IManaReceiver {
 
 				boolean flag = false;
 
-				int spawnCount = ReflectionHelper.getPrivateValue(MobSpawnerBaseLogic.class, logic, LibObfuscation.SPAWN_COUNT);
-				int spawnRange = ReflectionHelper.getPrivateValue(MobSpawnerBaseLogic.class, logic, LibObfuscation.SPAWN_RANGE);
-				int maxNearbyEntities = ReflectionHelper.getPrivateValue(MobSpawnerBaseLogic.class, logic, LibObfuscation.MAX_NEARBY_ENTITIES);
+				int spawnCount = ReflectionUtils.getInt(SPAWN_COUNT, logic);
+				int spawnRange = ReflectionUtils.getInt(SPAWN_RANGE, logic);
+				int maxNearbyEntities = ReflectionUtils.getInt(MAX_NEARBY_ENTITIES, logic);
 
 				for(int i = 0; i < spawnCount; ++i) {
 					Entity entity = EntityList.createEntityByName(logic.getEntityNameToSpawn(), logic.getSpawnerWorld());
@@ -103,9 +111,9 @@ public class TileSpawnerClaw extends TileMod implements IManaReceiver {
 	}
 
 	private void resetTimer(MobSpawnerBaseLogic logic) {
-		int maxSpawnDelay = ReflectionHelper.getPrivateValue(MobSpawnerBaseLogic.class, logic, LibObfuscation.MAX_SPAWN_DELAY);
-		int minSpawnDelay = ReflectionHelper.getPrivateValue(MobSpawnerBaseLogic.class, logic, LibObfuscation.MIN_SPAWN_DELAY);
-		List<MobSpawnerBaseLogic.WeightedRandomMinecart> potentialEntitySpawns = ReflectionHelper.getPrivateValue(MobSpawnerBaseLogic.class, logic, LibObfuscation.POTENTIAL_ENTITY_SPAWNS);
+		int maxSpawnDelay = ReflectionUtils.getInt(MAX_SPAWN_DELAY, logic);
+		int minSpawnDelay = ReflectionUtils.getInt(MIN_SPAWN_DELAY, logic);
+		List<MobSpawnerBaseLogic.WeightedRandomMinecart> potentialEntitySpawns = (List<MobSpawnerBaseLogic.WeightedRandomMinecart>) ReflectionUtils.getObject(POTENTIAL_ENTITY_SPAWNS, logic);
 
 		if(maxSpawnDelay <= minSpawnDelay)
 			logic.spawnDelay = minSpawnDelay;

--- a/src/main/java/vazkii/botania/common/core/helper/ObfuscationHelper.java
+++ b/src/main/java/vazkii/botania/common/core/helper/ObfuscationHelper.java
@@ -10,14 +10,24 @@
  */
 package vazkii.botania.common.core.helper;
 
+import java.lang.reflect.Field;
+
 import net.minecraft.client.particle.EffectRenderer;
 import net.minecraft.util.ResourceLocation;
 import vazkii.botania.common.lib.LibObfuscation;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import vazkii.botania.utils.ReflectionUtils;
 
 public class ObfuscationHelper {
 
+	private static Field particleTextureField;
+	private static boolean particleTextureResolved = false;
+
 	public static ResourceLocation getParticleTexture() {
-		return ReflectionHelper.getPrivateValue(EffectRenderer.class, null, LibObfuscation.PARTICLE_TEXTURES);
+		if(!particleTextureResolved) {
+			particleTextureField = ReflectionUtils.findField(EffectRenderer.class, LibObfuscation.PARTICLE_TEXTURES);
+			particleTextureResolved = true;
+		}
+
+		return (ResourceLocation) ReflectionUtils.getObject(particleTextureField, null);
 	}
 }

--- a/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
@@ -11,6 +11,7 @@
 package vazkii.botania.common.entity;
 
 import java.awt.Rectangle;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -74,11 +75,13 @@ import vazkii.botania.common.core.helper.Vector3;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.relic.ItemRelic;
 import vazkii.botania.common.lib.LibObfuscation;
-import cpw.mods.fml.relauncher.ReflectionHelper;
+import vazkii.botania.utils.ReflectionUtils;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 public class EntityDoppleganger extends EntityCreature implements IBotaniaBossWithShader {
+
+	private static final Field IS_BAD_EFFECT = ReflectionUtils.findField(Potion.class, LibObfuscation.IS_BAD_EFFECT);
 
 	public static final int SPAWN_TICKS = 160;
 	private static final float RANGE = 12F;
@@ -587,7 +590,7 @@ public class EntityDoppleganger extends EntityCreature implements IBotaniaBossWi
 				List<PotionEffect> remove = new ArrayList<>();
 				Collection<PotionEffect> active = player.getActivePotionEffects();
 				for(PotionEffect effect : active)
-					if(effect.getDuration() < 200 && effect.getIsAmbient() && !ReflectionHelper.<Boolean, Potion>getPrivateValue(Potion.class, Potion.potionTypes[effect.getPotionID()], LibObfuscation.IS_BAD_EFFECT))
+					if(effect.getDuration() < 200 && effect.getIsAmbient() && !ReflectionUtils.getBoolean(IS_BAD_EFFECT, Potion.potionTypes[effect.getPotionID()], true))
 						remove.add(effect);
 
 				active.removeAll(remove);

--- a/src/main/java/vazkii/botania/common/lexicon/page/PageCraftingRecipe.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageCraftingRecipe.java
@@ -13,6 +13,7 @@ package vazkii.botania.common.lexicon.page;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.lang.reflect.Field;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
@@ -33,14 +34,17 @@ import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.api.lexicon.LexiconRecipeMappings;
 import vazkii.botania.client.core.helper.RenderHelper;
 import vazkii.botania.client.lib.LibResources;
-import cpw.mods.fml.relauncher.ReflectionHelper;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import vazkii.botania.common.core.helper.InventoryHelper;
+import vazkii.botania.utils.ReflectionUtils;
 
 public class PageCraftingRecipe extends PageRecipe {
 
 	private static final ResourceLocation craftingOverlay = new ResourceLocation(LibResources.GUI_CRAFTING_OVERLAY);
+
+	private static final Field RECIPE_WIDTH = ReflectionUtils.findField(ShapedOreRecipe.class, 4);
+	private static final Field RECIPE_HEIGHT = ReflectionUtils.findField(ShapedOreRecipe.class, 5);
 
 	List<IRecipe> recipes;
 	int ticksElapsed = 0;
@@ -134,8 +138,8 @@ public class PageCraftingRecipe extends PageRecipe {
 					renderItemAtGridPos(gui, 1 + x, 1 + y, shaped.recipeItems[y * shaped.recipeWidth + x], true);
 		} else if(recipe instanceof ShapedOreRecipe) {
 			ShapedOreRecipe shaped = (ShapedOreRecipe) recipe;
-			int width = (Integer) ReflectionHelper.getPrivateValue(ShapedOreRecipe.class, shaped, 4);
-			int height = (Integer) ReflectionHelper.getPrivateValue(ShapedOreRecipe.class, shaped, 5);
+			int width = ReflectionUtils.getInt(RECIPE_WIDTH, shaped);
+			int height = ReflectionUtils.getInt(RECIPE_HEIGHT, shaped);
 
 			for(int y = 0; y < height; y++)
 				for(int x = 0; x < width; x++) {

--- a/src/main/java/vazkii/botania/utils/ReflectionUtils.java
+++ b/src/main/java/vazkii/botania/utils/ReflectionUtils.java
@@ -30,10 +30,26 @@ public final class ReflectionUtils {
 	}
 
 	public static int getInt(Field field, Object instance) {
+		return getInt(field, instance, 0);
+	}
+
+	public static int getInt(Field field, Object instance, int def) {
 		try {
 			return field.getInt(instance);
 		} catch(Exception e) {
-			return 0;
+			return def;
+		}
+	}
+
+	public static boolean getBoolean(Field field, Object instance) {
+		return getBoolean(field, instance, false);
+	}
+
+	public static boolean getBoolean(Field field, Object instance, boolean def) {
+		try {
+			return field.getBoolean(instance);
+		} catch(Exception e) {
+			return def;
 		}
 	}
 

--- a/src/main/java/vazkii/botania/utils/ReflectionUtils.java
+++ b/src/main/java/vazkii/botania/utils/ReflectionUtils.java
@@ -1,0 +1,31 @@
+package vazkii.botania.utils;
+
+import java.lang.reflect.Field;
+
+public final class ReflectionUtils {
+
+	private ReflectionUtils() {}
+
+	public static Field findField(Class<?> clazz, String... names) {
+		for(String name : names) {
+			try {
+				Field field = clazz.getDeclaredField(name);
+				field.setAccessible(true);
+				return field;
+			} catch(NoSuchFieldException e) {
+				// Try the next candidate name
+			}
+		}
+		return null;
+	}
+
+	public static int getInt(Field field, Object instance) {
+		try {
+			return field.getInt(instance);
+		} catch(Exception e) {
+			return 0;
+		}
+	}
+
+
+}

--- a/src/main/java/vazkii/botania/utils/ReflectionUtils.java
+++ b/src/main/java/vazkii/botania/utils/ReflectionUtils.java
@@ -19,6 +19,16 @@ public final class ReflectionUtils {
 		return null;
 	}
 
+	public static Field findField(Class<?> clazz, int index) {
+		try {
+			Field field = clazz.getDeclaredFields()[index];
+			field.setAccessible(true);
+			return field;
+		} catch(Exception e) {
+			return null;
+		}
+	}
+
 	public static int getInt(Field field, Object instance) {
 		try {
 			return field.getInt(instance);

--- a/src/main/java/vazkii/botania/utils/ReflectionUtils.java
+++ b/src/main/java/vazkii/botania/utils/ReflectionUtils.java
@@ -61,5 +61,25 @@ public final class ReflectionUtils {
 		}
 	}
 
+	public static void setInt(Field field, Object instance, int value) {
+		try {
+			field.setInt(instance, value);
+		} catch(Exception e) {
+		}
+	}
+
+	public static void setBoolean(Field field, Object instance, boolean value) {
+		try {
+			field.setBoolean(instance, value);
+		} catch(Exception e) {
+		}
+	}
+
+	public static void setObject(Field field, Object instance, Object value) {
+		try {
+			field.set(instance, value);
+		} catch(Exception e) {
+		}
+	}
 
 }

--- a/src/main/java/vazkii/botania/utils/ReflectionUtils.java
+++ b/src/main/java/vazkii/botania/utils/ReflectionUtils.java
@@ -27,5 +27,13 @@ public final class ReflectionUtils {
 		}
 	}
 
+	public static Object getObject(Field field, Object instance) {
+		try {
+			return field.get(instance);
+		} catch(Exception e) {
+			return null;
+		}
+	}
+
 
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
The uncached reflection in the SkyblockSkyRenderer caught my attention as it was shown in an allocation profiling. I decided to investigate the mod to cache some reflection, and there were quite some candidates. Tested on daily 658.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
