### PR TITLE
add null check for explosionsource

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
@@ -101,6 +101,7 @@ public class SubTileEntropinnyum extends SubTileGenerating {
             if (world.isRemote || mana != 0 || !(Math.abs(supertile.xCoord - posX) <= RANGE && Math.abs(supertile.yCoord - posY) <= RANGE && Math.abs(supertile.zCoord - posZ) <= RANGE)) {
                 return false;
             }
+			if (explosionSource == null) return false;
 
             explosionSource.setDead();
             mana += getMaxMana();


### PR DESCRIPTION
when ghast fireballs explode near an entropinnyum flower they cause a nullpointerexception, this fixes it

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
