### PR TITLE
fix: use renderViewEntity instead of player for rendering

### DIFF
--- a/src/main/java/vazkii/botania/client/core/handler/LightningHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/LightningHandler.java
@@ -2,10 +2,10 @@
  * This class was created by <Vazkii/ChickenBones>. It's distributed as
  * part of the Botania Mod. Get the Source Code in github:
  * https://github.com/Vazkii/Botania
- * 
+ *
  * Botania is Open Source and distributed under the
  * Botania License: http://botaniamod.net/license.php
- * 
+ *
  * File Created @ [Feb 3, 2014, 9:05:38 PM (GMT)]
  */
 package vazkii.botania.client.core.handler;
@@ -67,14 +67,13 @@ public class LightningHandler {
 		profiler.endStartSection("lightning");
 
 		float frame = event.partialTicks;
-		Entity entity = Minecraft.getMinecraft().thePlayer;
 		TextureManager render = Minecraft.getMinecraft().renderEngine;
 
-		interpPosX = entity.lastTickPosX + (entity.posX - entity.lastTickPosX) * frame;
-		interpPosY = entity.lastTickPosY + (entity.posY - entity.lastTickPosY) * frame;
-		interpPosZ = entity.lastTickPosZ + (entity.posZ - entity.lastTickPosZ) * frame;
-
 		Entity viewEntity = Minecraft.getMinecraft().renderViewEntity;
+		interpPosX = viewEntity.lastTickPosX + (viewEntity.posX - viewEntity.lastTickPosX) * frame;
+		interpPosY = viewEntity.lastTickPosY + (viewEntity.posY - viewEntity.lastTickPosY) * frame;
+		interpPosZ = viewEntity.lastTickPosZ + (viewEntity.posZ - viewEntity.lastTickPosZ) * frame;
+
 		scratchView.set(viewEntity.posX, viewEntity.posY + viewEntity.getEyeHeight(), viewEntity.posZ);
 
 		GL11.glPushMatrix();

--- a/src/main/java/vazkii/botania/client/render/world/SkyblockSkyRenderer.java
+++ b/src/main/java/vazkii/botania/client/render/world/SkyblockSkyRenderer.java
@@ -87,8 +87,8 @@ public class SkyblockSkyRenderer extends IRenderHandler {
 		float f6;
 
 		float insideVoid = 0;
-		if(mc.thePlayer.posY <= -2)
-			insideVoid = (float) Math.min(1F, -(mc.thePlayer.posY + 2) / 30F);
+		if(viewEntity.posY <= -2)
+			insideVoid = (float) Math.min(1F, -(viewEntity.posY + 2) / 30F);
 		
 		f1 = Math.max(0F, f1 - insideVoid);
 		f2 = Math.max(0F, f2 - insideVoid);


### PR DESCRIPTION
## Summary
use renderViewEntity instead of player for various client rendering


## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge